### PR TITLE
[feat] 헤더 UI 및 기능 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "react": "^19.0.0",
                 "react-calendar": "^5.1.0",
                 "react-dom": "^19.0.0",
+                "react-icons": "^5.5.0",
                 "react-router-dom": "^7.2.0",
                 "react-spinners": "^0.17.0"
             },
@@ -834,9 +835,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-            "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -848,10 +849,20 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+            "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
         "node_modules/@eslint/core": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-            "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+            "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -862,9 +873,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-            "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+            "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -899,13 +910,16 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.20.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-            "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+            "version": "9.33.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+            "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
             }
         },
         "node_modules/@eslint/object-schema": {
@@ -919,27 +933,14 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-            "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+            "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.12.0",
+                "@eslint/core": "^0.15.2",
                 "levn": "^0.4.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-            "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/json-schema": "^7.0.15"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1633,9 +1634,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2702,22 +2703,23 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.20.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
-            "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+            "version": "9.33.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
+            "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.19.0",
-                "@eslint/core": "^0.11.0",
-                "@eslint/eslintrc": "^3.2.0",
-                "@eslint/js": "9.20.0",
-                "@eslint/plugin-kit": "^0.2.5",
+                "@eslint/config-array": "^0.21.0",
+                "@eslint/config-helpers": "^0.3.1",
+                "@eslint/core": "^0.15.2",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.33.0",
+                "@eslint/plugin-kit": "^0.3.5",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.4.1",
+                "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
@@ -2725,9 +2727,9 @@
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.2.0",
-                "eslint-visitor-keys": "^4.2.0",
-                "espree": "^10.3.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2818,9 +2820,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2835,9 +2837,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2848,15 +2850,15 @@
             }
         },
         "node_modules/espree": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.14.0",
+                "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.0"
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3134,14 +3136,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -4985,6 +4988,15 @@
             },
             "peerDependencies": {
                 "react": "^19.0.0"
+            }
+        },
+        "node_modules/react-icons": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+            "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "*"
             }
         },
         "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "react": "^19.0.0",
         "react-calendar": "^5.1.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.2.0",
         "react-spinners": "^0.17.0"
     },

--- a/src/App.css
+++ b/src/App.css
@@ -25,6 +25,7 @@ html {
     --small-screen-gap: 8px;
 
     /* 폰트 사이즈 - 모바일 */
+    --font-size-3xs: 0.75rem; /* 12px */
     --font-size-2xs: 0.75rem; /* 12px */
     --font-size-xs: 0.813rem; /* 13px */
     --font-size-sm: 0.875rem; /* 14px */
@@ -40,6 +41,7 @@ html {
 /* 태블릿 크기 */
 @media (min-width: 768px) {
     :root {
+        --font-size-3xs: 0.75rem; /* 12px */
         --font-size-2xs: 0.75rem; /* 12px */
         --font-size-xs: 0.875rem; /* 14px */
         --font-size-sm: 1rem; /* 16px */
@@ -56,6 +58,7 @@ html {
 /* 데스크탑 크기 */
 @media (min-width: 1024px) {
     :root {
+        --font-size-3xs: 0.75rem; /* 12px */
         --font-size-2xs: 0.875rem; /* 14px */
         --font-size-xs: 1rem; /* 16px */
         --font-size-sm: 1.125rem; /* 18px */

--- a/src/App.css
+++ b/src/App.css
@@ -18,6 +18,8 @@ html {
     --background-color: #fafafa;
     --normal-text-color: #59636e;
 
+    --hover-gray-color: #e2e8f0;
+
     /* 반응형 변수 */
     --medium-screen-gap: 15px;
     --small-screen-gap: 8px;

--- a/src/components/BellBox.css
+++ b/src/components/BellBox.css
@@ -1,122 +1,122 @@
 .BellBox {
-  position: relative;
-  display: inline-block;
+    position: relative;
+    display: inline-block;
 }
 
-.notice-dropdown {
-  display: flex;
-  flex-direction: column;
-  position: absolute;
-  top: 45px;
-  right: 0;
-  max-height: 320px;
-  width: 260px;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0px 8px 20px rgba(0, 0, 0, 0.1);
-  padding: 12px;
-  z-index: 10;
-  overflow-y: auto;
-  gap: 10px;
+.BellBox .notification-dropdown {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 45px;
+    right: 0;
+    max-height: 320px;
+    width: 260px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0px 8px 20px rgba(0, 0, 0, 0.1);
+    padding: 12px;
+    z-index: 10;
+    overflow-y: auto;
+    gap: 10px;
 }
 
 .notice-header {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 6px;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 6px;
 }
 
 .mark-all-btn {
-  background-color: #f3f4f6;
-  border: none;
-  border-radius: 6px;
-  font-size: 13px;
-  padding: 4px 8px;
-  cursor: pointer;
-  color: #374151;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  transition: background 0.2s ease;
+    background-color: #f3f4f6;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    padding: 4px 8px;
+    cursor: pointer;
+    color: #374151;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    transition: background 0.2s ease;
 }
 
 .mark-all-btn:hover {
-  background-color: #e5e7eb;
+    background-color: #e5e7eb;
 }
 
 .notice-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  font-size: 14px;
-  background-color: #f9fafb;
-  border-radius: 8px;
-  padding: 10px;
-  gap: 8px;
-  transition: background-color 0.2s ease;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    font-size: 14px;
+    background-color: #f9fafb;
+    border-radius: 8px;
+    padding: 10px;
+    gap: 8px;
+    transition: background-color 0.2s ease;
 }
 
 .notice-item.unread {
-  background-color: #e0f2fe; /* 강조 */
-  font-weight: bold;
+    background-color: #e0f2fe; /* 강조 */
+    font-weight: bold;
 }
 
 .notice-main {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
 }
 
 .notice-link {
-  cursor: pointer;
-  color: #1d4ed8;
-  text-decoration: none;
-  font-weight: 500;
+    cursor: pointer;
+    color: #1d4ed8;
+    text-decoration: none;
+    font-weight: 500;
 }
 
 .notice-link:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 .notice-time {
-  font-size: 12px;
-  color: #888;
-  margin-top: 4px;
+    font-size: 12px;
+    color: #888;
+    margin-top: 4px;
 }
 
 .delete-btn {
-  background: none;
-  border: none;
-  padding: 4px;
-  cursor: pointer;
-  color: #888;
-  transition: color 0.2s ease;
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    color: #888;
+    transition: color 0.2s ease;
 }
 
 .delete-btn:hover {
-  color: #e11d48;
+    color: #e11d48;
 }
 
 .x {
-  width: 16px;
-  height: 16px;
+    width: 16px;
+    height: 16px;
 }
 
 .notice-empty {
-  padding: 20px 0;
-  text-align: center;
-  font-size: 14px;
-  color: #888;
+    padding: 20px 0;
+    text-align: center;
+    font-size: 14px;
+    color: #888;
 }
 
 @media (max-width: 500px) {
-  .notice-dropdown {
-    left: 50%;
-    width: 180px;
-    transform: translateX(-50%);
-  }
+    .notification-dropdown {
+        left: 50%;
+        width: 180px;
+        transform: translateX(-50%);
+    }
 
-  .notice-item {
-    font-size: 13px;
-  }
+    .notice-item {
+        font-size: 13px;
+    }
 }

--- a/src/components/BellBox.css
+++ b/src/components/BellBox.css
@@ -1,25 +1,6 @@
 .BellBox {
-  font-size: 15px;
   position: relative;
   display: inline-block;
-}
-
-.bell-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  border: none;
-  border-radius: 50%;
-  width: 36px;
-  height: 36px;
-  background-color: #f1f5f9;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.bell-btn:hover {
-  background-color: #e2e8f0;
 }
 
 .notice-dropdown {

--- a/src/components/BellBox.css
+++ b/src/components/BellBox.css
@@ -14,9 +14,7 @@
     background: white;
     border-radius: 12px;
     box-shadow: 0px 8px 20px rgba(0, 0, 0, 0.1);
-    padding: 12px;
     z-index: 10;
-    gap: 10px;
 }
 
 .BellBox .notification-dropdown::before {
@@ -24,115 +22,128 @@
     position: absolute;
     top: -8px;
     right: 20px;
-    border-width: 0 8px 8px 8px; /* 아래쪽 삼각형 */
+    border-width: 0 8px 8px 8px;
     border-style: solid;
-    border-color: transparent transparent white transparent; /* 화살표 색 */
+    border-color: transparent transparent white transparent;
     width: 0;
     height: 0;
     z-index: 11;
 }
 
-.notification-header {
-    display: flex;
-    justify-content: flex-end;
-    margin-bottom: 6px;
-}
-
-.BellBox .notification-list {
-    overflow-y: auto;
-}
-
-.mark-all-btn {
-    background-color: #f3f4f6;
-    border: none;
-    border-radius: 6px;
-    font-size: 13px;
-    padding: 4px 8px;
-    cursor: pointer;
-    color: #374151;
+.BellBox .notification-header {
     display: flex;
     align-items: center;
-    gap: 4px;
-    transition: background 0.2s ease;
-}
-
-.mark-all-btn:hover {
-    background-color: #e5e7eb;
-}
-
-.notice-item {
-    display: flex;
     justify-content: space-between;
-    align-items: flex-start;
-    font-size: 14px;
-    background-color: #f9fafb;
-    border-radius: 8px;
-    padding: 10px;
-    gap: 8px;
-    transition: background-color 0.2s ease;
+    padding: 16px 16px 12px;
+    border-bottom: 1px solid var(--light-border-color);
 }
 
-.notice-item.unread {
-    background-color: #e0f2fe; /* 강조 */
-    font-weight: bold;
-}
-
-.notice-main {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-}
-
-.notice-link {
-    cursor: pointer;
-    color: #1d4ed8;
-    text-decoration: none;
+.BellBox .notification-title {
+    font-size: var(--font-size-xs);
     font-weight: 500;
+    line-height: 20px;
+    color: #44474b;
 }
 
-.notice-link:hover {
-    text-decoration: underline;
-}
-
-.notice-time {
-    font-size: 12px;
-    color: #888;
-    margin-top: 4px;
-}
-
-.delete-btn {
-    background: none;
-    border: none;
-    padding: 4px;
-    cursor: pointer;
-    color: #888;
+.BellBox .read-all-btn {
+    font-size: var(--font-size-3xs);
+    font-weight: 500;
+    color: #9fa4ab;
+    line-height: 14px;
     transition: color 0.2s ease;
 }
 
-.delete-btn:hover {
+.BellBox .read-all-btn:hover {
+    font-weight: 700;
+    color: #656a71;
+}
+
+.BellBox .notification-area {
+    overflow: hidden;
+    margin-right: 4px;
+}
+
+.BellBox .notification-wrap {
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: 260px;
+    margin-right: calc(4px - 17px);
+    padding-right: 0;
+}
+
+.BellBox .notification-list {
+    padding: 0 4px;
+    overflow: hidden;
+    border-radius: 0 0 22px 12px;
+}
+
+.BellBox .notification-item {
+    position: relative;
+    display: flex;
+    padding: 18px 40px 20px 20px;
+}
+
+.BellBox .notification-item + .notification-item {
+    border-top: 1px solid var(--light-border-color);
+}
+
+.BellBox .unread {
+    background-color: #f0f9ff;
+}
+
+.BellBox .notification-time {
+    position: relative;
+    display: inline-block;
+    font-size: var(--font-size-3xs);
+    font-weight: 500;
+    line-height: 14px;
+    color: #9fa4ab;
+    vertical-align: bottom;
+}
+
+.BellBox .notification-content {
+    font-size: var(--font-size-2xs);
+    font-weight: 500;
+    line-height: 22px;
+    color: #44474b;
+    white-space: pre-line;
+}
+
+.BellBox .notification-content:hover {
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.BellBox .notification-delete-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    color: #9fa4ab;
+    transition: color 0.2s ease;
+    padding: 3px;
+}
+
+.BellBox .notification-delete-btn:hover {
     color: #e11d48;
 }
 
-.x {
+.BellBox .notification-delete-btn svg {
     width: 16px;
     height: 16px;
 }
 
-.notice-empty {
+.BellBox .notification-empty {
+    display: flex;
+    justify-content: center;
     padding: 20px 0;
+    font-size: var(--font-size-2xs);
     text-align: center;
-    font-size: 14px;
+    font-weight: 500;
     color: #888;
-}
-
-@media (max-width: 500px) {
-    .notification-dropdown {
-        left: 50%;
-        width: 180px;
-        transform: translateX(-50%);
-    }
-
-    .notice-item {
-        font-size: 13px;
-    }
 }

--- a/src/components/BellBox.css
+++ b/src/components/BellBox.css
@@ -16,14 +16,30 @@
     box-shadow: 0px 8px 20px rgba(0, 0, 0, 0.1);
     padding: 12px;
     z-index: 10;
-    overflow-y: auto;
     gap: 10px;
 }
 
-.notice-header {
+.BellBox .notification-dropdown::before {
+    content: "";
+    position: absolute;
+    top: -8px;
+    right: 20px;
+    border-width: 0 8px 8px 8px; /* 아래쪽 삼각형 */
+    border-style: solid;
+    border-color: transparent transparent white transparent; /* 화살표 색 */
+    width: 0;
+    height: 0;
+    z-index: 11;
+}
+
+.notification-header {
     display: flex;
     justify-content: flex-end;
     margin-bottom: 6px;
+}
+
+.BellBox .notification-list {
+    overflow-y: auto;
 }
 
 .mark-all-btn {

--- a/src/components/BellBox.jsx
+++ b/src/components/BellBox.jsx
@@ -1,10 +1,11 @@
+import "./BellBox.css";
+
 import { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Bell, X, Check } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
 import Reddot from "./Reddot";
-import "./BellBox.css";
 import axiosInstance from "./utils/AxiosInstance";
 
 const getNoticeIcon = (type) => {
@@ -59,15 +60,17 @@ const BellBox = ({ notices, setNotices }) => {
 
     useEffect(() => {
         const handleClickOutside = (e) => {
-            if (boxRef.current && !boxRef.current.contains(e.target)) setIsOpen(false);
+            if (boxRef.current && !boxRef.current.contains(e.target))
+                setIsOpen(false);
         };
         document.addEventListener("mousedown", handleClickOutside);
-        return () => document.removeEventListener("mousedown", handleClickOutside);
+        return () =>
+            document.removeEventListener("mousedown", handleClickOutside);
     }, []);
 
     return (
         <div className="BellBox" ref={boxRef}>
-            <button className="bell-btn" onClick={() => setIsOpen(!isOpen)}>
+            <button className="bell-btn header-btn" onClick={() => setIsOpen(!isOpen)}>
                 <Bell />
                 {notices.length > 0 && <Reddot count={notices.length} />}
             </button>
@@ -83,7 +86,10 @@ const BellBox = ({ notices, setNotices }) => {
                     >
                         {notices.length > 0 && (
                             <div className="notice-header">
-                                <button className="mark-all-btn" onClick={handleMarkAllAsRead}>
+                                <button
+                                    className="mark-all-btn"
+                                    onClick={handleMarkAllAsRead}
+                                >
                                     <Check className="check-icon" />
                                     모두 읽기
                                 </button>
@@ -94,18 +100,28 @@ const BellBox = ({ notices, setNotices }) => {
                             notices.map((notice) => (
                                 <div
                                     key={notice.id}
-                                    className={`notice-item ${notice.read ? "" : "unread"}`}
+                                    className={`notice-item ${
+                                        notice.read ? "" : "unread"
+                                    }`}
                                 >
                                     <div className="notice-main">
                                         <span
                                             className="notice-link"
-                                            onClick={() => handleNoticeClick(notice)}
+                                            onClick={() =>
+                                                handleNoticeClick(notice)
+                                            }
                                         >
-                                            {getNoticeIcon(notice.type)} {notice.content}
+                                            {getNoticeIcon(notice.type)}{" "}
+                                            {notice.content}
                                         </span>
                                         <span className="notice-time">
                                             {notice.createdAt
-                                                ? formatDistanceToNow(new Date(notice.createdAt), { addSuffix: true })
+                                                ? formatDistanceToNow(
+                                                      new Date(
+                                                          notice.createdAt
+                                                      ),
+                                                      { addSuffix: true }
+                                                  )
                                                 : "방금 전"}
                                         </span>
                                     </div>
@@ -118,7 +134,9 @@ const BellBox = ({ notices, setNotices }) => {
                                 </div>
                             ))
                         ) : (
-                            <div className="notice-empty">새로운 알림이 없습니다.</div>
+                            <div className="notice-empty">
+                                새로운 알림이 없습니다.
+                            </div>
                         )}
                     </motion.div>
                 )}

--- a/src/components/BellBox.jsx
+++ b/src/components/BellBox.jsx
@@ -83,7 +83,7 @@ const BellBox = ({ notices, setNotices }) => {
             <AnimatePresence>
                 {isOpen && (
                     <motion.div
-                        className="notice-dropdown"
+                        className="notification-dropdown"
                         initial={{ opacity: 0, height: 0 }}
                         animate={{ opacity: 1, height: "auto" }}
                         exit={{ opacity: 0, height: 0 }}

--- a/src/components/BellBox.jsx
+++ b/src/components/BellBox.jsx
@@ -90,7 +90,7 @@ const BellBox = ({ notices, setNotices }) => {
                         transition={{ duration: 0.2 }}
                     >
                         {notices.length > 0 && (
-                            <div className="notice-header">
+                            <div className="notification-header">
                                 <button
                                     className="mark-all-btn"
                                     onClick={handleMarkAllAsRead}
@@ -102,42 +102,48 @@ const BellBox = ({ notices, setNotices }) => {
                         )}
 
                         {notices.length > 0 ? (
-                            notices.map((notice) => (
-                                <div
-                                    key={notice.id}
-                                    className={`notice-item ${
-                                        notice.read ? "" : "unread"
-                                    }`}
-                                >
-                                    <div className="notice-main">
-                                        <span
-                                            className="notice-link"
+                            <div className="notification-list">
+                                {notices.map((notice) => (
+                                    <div
+                                        key={notice.id}
+                                        className={`notice-item ${
+                                            notice.read ? "" : "unread"
+                                        }`}
+                                    >
+                                        <div className="notice-main">
+                                            <span
+                                                className="notice-link"
+                                                onClick={() =>
+                                                    handleNoticeClick(notice)
+                                                }
+                                            >
+                                                {getNoticeIcon(notice.type)}{" "}
+                                                {notice.content}
+                                            </span>
+                                            <span className="notice-time">
+                                                {notice.createdAt
+                                                    ? formatDistanceToNow(
+                                                          new Date(
+                                                              notice.createdAt
+                                                          ),
+                                                          {
+                                                              addSuffix: true,
+                                                          }
+                                                      )
+                                                    : "방금 전"}
+                                            </span>
+                                        </div>
+                                        <button
+                                            className="delete-btn"
                                             onClick={() =>
-                                                handleNoticeClick(notice)
+                                                handleDelete(notice.id)
                                             }
                                         >
-                                            {getNoticeIcon(notice.type)}{" "}
-                                            {notice.content}
-                                        </span>
-                                        <span className="notice-time">
-                                            {notice.createdAt
-                                                ? formatDistanceToNow(
-                                                      new Date(
-                                                          notice.createdAt
-                                                      ),
-                                                      { addSuffix: true }
-                                                  )
-                                                : "방금 전"}
-                                        </span>
+                                            <X className="x" />
+                                        </button>
                                     </div>
-                                    <button
-                                        className="delete-btn"
-                                        onClick={() => handleDelete(notice.id)}
-                                    >
-                                        <X className="x" />
-                                    </button>
-                                </div>
-                            ))
+                                ))}
+                            </div>
                         ) : (
                             <div className="notice-empty">
                                 새로운 알림이 없습니다.

--- a/src/components/BellBox.jsx
+++ b/src/components/BellBox.jsx
@@ -70,7 +70,12 @@ const BellBox = ({ notices, setNotices }) => {
 
     return (
         <div className="BellBox" ref={boxRef}>
-            <button className="bell-btn header-btn" onClick={() => setIsOpen(!isOpen)}>
+            <button
+                className={`bell-btn header-btn ${
+                    notices.length > 0 ? "header-shake" : ""
+                }`}
+                onClick={() => setIsOpen(!isOpen)}
+            >
                 <Bell />
                 {notices.length > 0 && <Reddot count={notices.length} />}
             </button>

--- a/src/components/BellBox.jsx
+++ b/src/components/BellBox.jsx
@@ -2,7 +2,7 @@ import "./BellBox.css";
 
 import { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Bell, X, Check } from "lucide-react";
+import { Bell, X } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
 import Reddot from "./Reddot";
@@ -91,61 +91,69 @@ const BellBox = ({ notices, setNotices }) => {
                     >
                         {notices.length > 0 && (
                             <div className="notification-header">
+                                <span className="notification-title">알림</span>
                                 <button
-                                    className="mark-all-btn"
+                                    className="read-all-btn"
                                     onClick={handleMarkAllAsRead}
                                 >
-                                    <Check className="check-icon" />
                                     모두 읽기
                                 </button>
                             </div>
                         )}
 
                         {notices.length > 0 ? (
-                            <div className="notification-list">
-                                {notices.map((notice) => (
-                                    <div
-                                        key={notice.id}
-                                        className={`notice-item ${
-                                            notice.read ? "" : "unread"
-                                        }`}
-                                    >
-                                        <div className="notice-main">
-                                            <span
-                                                className="notice-link"
-                                                onClick={() =>
-                                                    handleNoticeClick(notice)
-                                                }
+                            <div className="notification-area">
+                                <div className="notification-wrap">
+                                    <ul className="notification-list">
+                                        {notices.map((notice) => (
+                                            <li
+                                                key={notice.id}
+                                                className={`notification-item ${
+                                                    notice.read ? "" : "unread"
+                                                }`}
                                             >
-                                                {getNoticeIcon(notice.type)}{" "}
-                                                {notice.content}
-                                            </span>
-                                            <span className="notice-time">
-                                                {notice.createdAt
-                                                    ? formatDistanceToNow(
-                                                          new Date(
-                                                              notice.createdAt
-                                                          ),
-                                                          {
-                                                              addSuffix: true,
-                                                          }
-                                                      )
-                                                    : "방금 전"}
-                                            </span>
-                                        </div>
-                                        <button
-                                            className="delete-btn"
-                                            onClick={() =>
-                                                handleDelete(notice.id)
-                                            }
-                                        >
-                                            <X className="x" />
-                                        </button>
-                                    </div>
-                                ))}
+                                                <div className="notification-main">
+                                                    <p
+                                                        className="notification-content"
+                                                        onClick={() =>
+                                                            handleNoticeClick(
+                                                                notice
+                                                            )
+                                                        }
+                                                    >
+                                                        {getNoticeIcon(
+                                                            notice.type
+                                                        )}{" "}
+                                                        {notice.content}
+                                                    </p>
+                                                    <span className="notification-time">
+                                                        {notice.createdAt
+                                                            ? formatDistanceToNow(
+                                                                  new Date(
+                                                                      notice.createdAt
+                                                                  ),
+                                                                  {
+                                                                      addSuffix: true,
+                                                                  }
+                                                              )
+                                                            : "방금 전"}
+                                                    </span>
+                                                </div>
+                                                <button
+                                                    className="notification-delete-btn"
+                                                    onClick={() =>
+                                                        handleDelete(notice.id)
+                                                    }
+                                                >
+                                                    <X />
+                                                </button>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
                             </div>
                         ) : (
-                            <div className="notice-empty">
+                            <div className="notification-empty">
                                 새로운 알림이 없습니다.
                             </div>
                         )}

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -236,7 +236,7 @@
     bottom: 7px;
     left: 0;
     transform: translateY(100%);
-    z-index: 100;
+    z-index: 110;
 }
 
 .header .more-gap:hover .profile-menu-list-area {

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -167,6 +167,42 @@
 
 /* 헤더 우측 */
 
+.header .header-wrap {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    height: 100%;
+}
+
+.header .btn-wrap {
+    display: flex;
+    flex: none;
+    align-items: center;
+    height: 100%;
+    position: relative;
+}
+
+.header-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    position: relative;
+    flex: none;
+    transition: background-color 0.2s ease;
+}
+
+.header-btn:hover {
+    background-color: var(--hover-gray-color);
+}
+
+.header-btn svg {
+    flex: none;
+    user-select: none;
+}
+
 .logout-btn {
     display: flex;
     align-items: center;
@@ -183,21 +219,4 @@
 
 .logout-btn:hover {
     opacity: 0.5;
-}
-
-.header-space {
-    flex-grow: 1;
-    height: 100%;
-    display: flex;
-    justify-content: end;
-    align-items: center;
-    margin-right: 25px;
-    gap: 60px;
-}
-
-.util-box {
-    display: flex;
-    justify-content: end;
-    align-content: center;
-    gap: 20px;
 }

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -245,7 +245,7 @@
 
 .header .profile-menu-list {
     overflow: hidden;
-    width: 174px;
+    width: 164px;
     padding: 11px 0;
     border: 1px solid #cfd1d5;
     border-radius: 12px;
@@ -345,5 +345,19 @@
     49%,
     100% {
         transform: rotate(0deg);
+    }
+}
+
+@media (min-width: 1280px) and (max-width: 1532px) {
+    .header .profile-menu-list-area {
+        right: calc((100vw - 1290px) / -2);
+        left: auto;
+    }
+}
+
+@media (max-width: 1279px) {
+    .header .profile-menu-list-area {
+        right: 0;
+        left: auto;
     }
 }

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -30,7 +30,7 @@
 
 .header .menu-btn {
     display: flex;
-    margin-right: 16px;
+    margin-right: 14px;
     justify-content: center;
     align-items: center;
     background-color: transparent;
@@ -143,22 +143,10 @@
 .header .submenu-icon {
     width: 28px;
     height: 28px;
-    margin-right: 12px;
+    margin-right: 8px;
+    margin-left: 4px;
     border-radius: 8px;
     flex-shrink: 0;
-}
-
-.header .icon-blue {
-    background-color: #748ffc;
-}
-.header .icon-green {
-    background-color: #51cf66;
-}
-.header .icon-yellow {
-    background-color: #fcc419;
-}
-.header .icon-purple {
-    background-color: #b197fc;
 }
 
 .header .submenu-content {

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -174,6 +174,10 @@
     height: 100%;
 }
 
+.header .header-wrap + .header-wrap {
+    margin-left: 24px;
+}
+
 .header .btn-wrap {
     display: flex;
     flex: none;
@@ -183,7 +187,7 @@
 }
 
 .header .more-gap {
-    margin-left: 4px;
+    margin-left: 6px;
 }
 
 .header .more-gap .camera-icon {
@@ -214,12 +218,42 @@
 .header .profile {
     background-size: cover;
     background-position: 50%;
-    border: 1px solid rgba(18, 22, 25, .1);
+    border: 1px solid rgba(18, 22, 25, 0.1);
+}
+
+.header .profile:hover {
+    background-color: inherit;
 }
 
 .header .profile .profile-pic-container {
     width: 100%;
     height: 100%;
+}
+
+.header .admin-btn::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: -7px;
+    transform: translateY(-50%);
+    height: 20px;
+    border: 1px solid var(--base-border-color);
+    box-sizing: border-box;
+}
+
+.header .admin-btn {
+    font-size: var(--font-size-2xs);
+    font-weight: 600;
+    line-height: 16px;
+    color: var(--normal-text-color);
+    border-radius: 4px;
+    padding: 6px 8px;
+    border: 1px solid var(--base-border-color);
+    margin-left: 12px;
+}
+
+.header .admin-btn:hover {
+    background-color: rgba(51, 52, 54, 0.05);
 }
 
 .logout-btn {

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -182,6 +182,14 @@
     position: relative;
 }
 
+.header .more-gap {
+    margin-left: 4px;
+}
+
+.header .more-gap .camera-icon {
+    display: none;
+}
+
 .header-btn {
     display: flex;
     align-items: center;
@@ -201,6 +209,17 @@
 .header-btn svg {
     flex: none;
     user-select: none;
+}
+
+.header .profile {
+    background-size: cover;
+    background-position: 50%;
+    border: 1px solid rgba(18, 22, 25, .1);
+}
+
+.header .profile .profile-pic-container {
+    width: 100%;
+    height: 100%;
 }
 
 .logout-btn {

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -303,20 +303,47 @@
     background-color: rgba(51, 52, 54, 0.05);
 }
 
-.logout-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: black;
-    width: 20px;
-    height: 20px;
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-    font-size: 13px;
-    /* 폰트 크기 조정 */
+.header .Reddot {
+    top: 12px;
+    right: 12px;
+    width: 11px;
+    height: 11px;
+    padding: 6px;
 }
 
-.logout-btn:hover {
-    opacity: 0.5;
+.header .Reddot .content {
+    font-size: 8px;
+}
+
+.header-shake {
+    animation: header-shake 2.15s infinite;
+}
+
+@keyframes header-shake {
+    0%,
+    49% {
+        transform: rotate(0deg);
+    }
+    7% {
+        transform: rotate(10deg);
+    }
+    14% {
+        transform: rotate(-10deg);
+    }
+    21% {
+        transform: rotate(14deg);
+    }
+    28% {
+        transform: rotate(-14deg);
+    }
+    35% {
+        transform: rotate(5deg);
+    }
+    42% {
+        transform: rotate(-5deg);
+    }
+    49%,
+    100% {
+        transform: rotate(0deg);
+    }
 }

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -230,6 +230,53 @@
     height: 100%;
 }
 
+.header .profile-menu-list-area {
+    display: none;
+    position: absolute;
+    bottom: 7px;
+    left: 0;
+    transform: translateY(100%);
+    z-index: 100;
+}
+
+.header .more-gap:hover .profile-menu-list-area {
+    display: block;
+}
+
+.header .profile-menu-list {
+    overflow: hidden;
+    width: 174px;
+    padding: 11px 0;
+    border: 1px solid #cfd1d5;
+    border-radius: 12px;
+    background-color: #fff;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04), 0 16px 25px rgba(0, 0, 0, 0.1);
+}
+
+.header .profile-menu-item {
+    display: flex;
+    align-items: center;
+    height: 40px;
+    padding: 0 20px;
+    cursor: pointer;
+}
+
+.header .profile-menu-item:hover {
+    background-color: #f4f4f5;
+    color: #121619;
+}
+
+.header .logout {
+    border-top: 1px solid var(--light-border-color);
+}
+
+.header .profile-menu-btn {
+    color: #44474b;
+    font-size: var(--font-size-2xs);
+    font-weight: 500;
+    line-height: 16px;
+}
+
 .header .admin-btn::before {
     content: "";
     position: absolute;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -18,6 +18,7 @@ import {
     FcSms,
     FcPaid,
 } from "react-icons/fc";
+import MyProfile from "./Myprofile";
 
 function Header() {
     const { user } = useContext(UserContext);
@@ -321,7 +322,16 @@ function Header() {
                                 />
                             )}
                         </div>
-                        <div className="btn-wrap"></div>
+                        <div className="btn-wrap more-gap">
+                            <button
+                                aria-label="프로필"
+                                className="header-btn profile"
+                            >
+                                <MyProfile
+                                    profileImageUrl={user?.profileImageUrl}
+                                />
+                            </button>
+                        </div>
                         {/* <button
                             className="logout-btn"
                             title="로그아웃"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -339,12 +339,19 @@ function Header() {
                         >
                             <LogOut />
                         </button> */}
-                        {/* {user?.roles?.includes("ADMIN") && (
-                            <button onClick={goToAdminPage}>
-                                관리자 페이지
-                            </button>
-                        )} */}
                     </div>
+                    {user?.roles?.includes("ADMIN") && (
+                        <div className="header-wrap">
+                            <div className="btn-wrap">
+                                <button
+                                    className="admin-btn"
+                                    onClick={goToAdminPage}
+                                >
+                                    관리자
+                                </button>
+                            </div>
+                        </div>
+                    )}
                 </div>
                 <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />{" "}
             </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import "./Header.css";
 
-import { LogOut, Menu } from "lucide-react";
+import { Menu } from "lucide-react";
 import Bellbox from "./BellBox";
 import MailBox from "./MailBox";
 import { Link, useNavigate } from "react-router-dom";

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -366,7 +366,7 @@ function Header() {
                             </div>
                         </div>
                     </div>
-                    {/* {user?.roles?.includes("ADMIN") && (
+                    {user?.roles?.includes("ADMIN") && (
                         <div className="header-wrap">
                             <div className="btn-wrap">
                                 <button
@@ -377,7 +377,7 @@ function Header() {
                                 </button>
                             </div>
                         </div>
-                    )} */}
+                    )}
                 </div>
                 <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />{" "}
             </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -18,7 +18,7 @@ import {
     FcPaid,
 } from "react-icons/fc";
 
-function Header({ title }) {
+function Header() {
     const { user } = useContext(UserContext);
     const [notices, setNotices] = useState([]);
     const [newMailCount, setNewMailCount] = useState(0);
@@ -304,7 +304,6 @@ function Header({ title }) {
                             </div>
                         </div>
                     </div>
-                    {/* <h2 style={{ marginLeft: "10px" }}>{title}</h2> */}
                 </div>
                 <div className="header-inner">
                     <div className="header-space">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -45,6 +45,17 @@ function Header() {
         }
     };
 
+    const profileMenuItems = [
+        {
+            label: "마이 페이지",
+            onClick: () => navigate("/mypage"),
+        },
+        {
+            label: "로그아웃",
+            onClick: handleLogout,
+        },
+    ];
+
     const goToAdminPage = () => navigate("/admin");
 
     const handleSearch = async () => {
@@ -331,14 +342,29 @@ function Header() {
                                     profileImageUrl={user?.profileImageUrl}
                                 />
                             </button>
+                            <div className="profile-menu-list-area">
+                                <ul className="profile-menu-list">
+                                    {profileMenuItems.map((item, index) => (
+                                        <li
+                                            key={index}
+                                            className={`profile-menu-item ${
+                                                index ===
+                                                profileMenuItems.length - 1
+                                                    ? "logout"
+                                                    : ""
+                                            }`}
+                                        >
+                                            <button
+                                                className="profile-menu-btn"
+                                                onClick={item.onClick}
+                                            >
+                                                {item.label}
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
                         </div>
-                        {/* <button
-                            className="logout-btn"
-                            title="로그아웃"
-                            onClick={handleLogout}
-                        >
-                            <LogOut />
-                        </button> */}
                     </div>
                     {user?.roles?.includes("ADMIN") && (
                         <div className="header-wrap">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,11 +2,21 @@ import "./Header.css";
 import { LogOut, Menu } from "lucide-react";
 import Bellbox from "./BellBox";
 import MailBox from "./MailBox";
-import { Link, useNavigate, useLocation } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import axiosInstance from "./utils/AxiosInstance";
 import { useContext, useEffect, useState } from "react";
 import { UserContext } from "./utils/UserContext";
 import Sidebar from "./Sidebar";
+import {
+    FcAdvertising,
+    FcGraduationCap,
+    FcManager,
+    FcRating,
+    FcCollaboration,
+    FcLock,
+    FcSms,
+    FcPaid,
+} from "react-icons/fc";
 
 function Header({ title }) {
     const { user } = useContext(UserContext);
@@ -20,19 +30,18 @@ function Header({ title }) {
     const closeSidebar = () => setSidebarOpen(false);
 
     const handleLogout = async () => {
-    try {
+        try {
+            await axiosInstance.post("member/logout");
 
-        await axiosInstance.post("member/logout");
-
-        // 로그아웃 성공 시 클라이언트 상태 정리
-        localStorage.clear();
-        window.location.href = "/login";
-    } catch (error) {
-        console.error("Logout failed:", error);
-        // 로그아웃 실패 시에도 강제 리다이렉트 할지, 사용자에게 알릴지는 선택
-        window.location.href = "/login";
-    }
-};
+            // 로그아웃 성공 시 클라이언트 상태 정리
+            localStorage.clear();
+            window.location.href = "/login";
+        } catch (error) {
+            console.error("Logout failed:", error);
+            // 로그아웃 실패 시에도 강제 리다이렉트 할지, 사용자에게 알릴지는 선택
+            window.location.href = "/login";
+        }
+    };
 
     const goToAdminPage = () => navigate("/admin");
 
@@ -101,7 +110,9 @@ function Header({ title }) {
                                 <div className="tooltip">
                                     <div className="gnb-sub">
                                         <Link className="submenu-item">
-                                            <div className="submenu-icon icon-blue" />
+                                            <div className="submenu-icon">
+                                                <FcAdvertising />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     전체 공지사항
@@ -116,7 +127,9 @@ function Header({ title }) {
                                             to="/main/community/notice_c"
                                             className="submenu-item"
                                         >
-                                            <div className="submenu-icon icon-green" />
+                                            <div className="submenu-icon">
+                                                <FcGraduationCap />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     공지사항
@@ -130,7 +143,9 @@ function Header({ title }) {
                                             to="/main/community/notice"
                                             className="submenu-item"
                                         >
-                                            <div className="submenu-icon icon-yellow" />
+                                            <div className="submenu-icon">
+                                                <FcManager />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     조교알림
@@ -169,7 +184,9 @@ function Header({ title }) {
                                             to="/main/community/popular"
                                             className="submenu-item"
                                         >
-                                            <div className="submenu-icon icon-blue" />
+                                            <div className="submenu-icon">
+                                                <FcRating />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     인기 게시판
@@ -184,7 +201,9 @@ function Header({ title }) {
                                             to="/main/community/free"
                                             className="submenu-item"
                                         >
-                                            <div className="submenu-icon icon-green" />
+                                            <div className="submenu-icon">
+                                                <FcCollaboration />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     자유 게시판
@@ -199,7 +218,9 @@ function Header({ title }) {
                                             to="/main/community/secret"
                                             className="submenu-item"
                                         >
-                                            <div className="submenu-icon icon-yellow" />
+                                            <div className="submenu-icon">
+                                                <FcLock />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     비밀 게시판
@@ -214,7 +235,9 @@ function Header({ title }) {
                                             to="/main/community/review"
                                             className="submenu-item"
                                         >
-                                            <div className="submenu-icon icon-purple" />
+                                            <div className="submenu-icon">
+                                                <FcSms />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     후기 게시판
@@ -248,7 +271,9 @@ function Header({ title }) {
                                             to="/main/community/market"
                                             className="submenu-item"
                                         >
-                                            <div className="submenu-icon icon-blue" />
+                                            <div className="submenu-icon">
+                                                <FcPaid />
+                                            </div>
                                             <div className="submenu-content">
                                                 <div className="submenu-title">
                                                     책 장터

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,5 @@
 import "./Header.css";
+
 import { LogOut, Menu } from "lucide-react";
 import Bellbox from "./BellBox";
 import MailBox from "./MailBox";
@@ -306,30 +307,33 @@ function Header() {
                     </div>
                 </div>
                 <div className="header-inner">
-                    <div className="header-space">
-                        <div className="util-box">
-                            {user?.roles?.includes("ADMIN") && (
-                                <button onClick={goToAdminPage}>
-                                    관리자 페이지
-                                </button>
+                    <div className="header-wrap">
+                        <div className="btn-wrap">
+                            {!isMobile && (
+                                <MailBox newMailCount={newMailCount} />
                             )}
+                        </div>
+                        <div className="btn-wrap">
                             {!isMobile && (
                                 <Bellbox
                                     notices={notices}
                                     setNotices={setNotices}
                                 />
                             )}
-                            {!isMobile && (
-                                <MailBox newMailCount={newMailCount} />
-                            )}
                         </div>
-                        <button
+                        <div className="btn-wrap"></div>
+                        {/* <button
                             className="logout-btn"
                             title="로그아웃"
                             onClick={handleLogout}
                         >
                             <LogOut />
-                        </button>
+                        </button> */}
+                        {/* {user?.roles?.includes("ADMIN") && (
+                            <button onClick={goToAdminPage}>
+                                관리자 페이지
+                            </button>
+                        )} */}
                     </div>
                 </div>
                 <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />{" "}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -366,7 +366,7 @@ function Header() {
                             </div>
                         </div>
                     </div>
-                    {user?.roles?.includes("ADMIN") && (
+                    {/* {user?.roles?.includes("ADMIN") && (
                         <div className="header-wrap">
                             <div className="btn-wrap">
                                 <button
@@ -377,7 +377,7 @@ function Header() {
                                 </button>
                             </div>
                         </div>
-                    )}
+                    )} */}
                 </div>
                 <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />{" "}
             </div>

--- a/src/components/MailBox.css
+++ b/src/components/MailBox.css
@@ -2,18 +2,3 @@
     position: relative;
 
 }
-.mail-btn{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    border: none;
-    border-radius: 5px;
-    padding: 2px;
-    background-color: #e8e6e6;
-    cursor: pointer;
-}
-
-.mail-btn:hover {
-    opacity: 0.5;
-}

--- a/src/components/MailBox.jsx
+++ b/src/components/MailBox.jsx
@@ -1,7 +1,8 @@
+import "./MailBox.css"
+
 import { MessagesSquare } from "lucide-react";
 import { useNavigate } from "react-router-dom"; // ← 추가
 import Reddot from "./Reddot";
-import "./MailBox.css"
 
 const MailBox = ({newMailCount}) => {
     const navigate = useNavigate(); // ← 훅 호출
@@ -12,7 +13,7 @@ const MailBox = ({newMailCount}) => {
 
     return (
         <div className="MailBox">
-            <button className="mail-btn" onClick={handleClick}>
+            <button className="mail-btn header-btn" onClick={handleClick}>
                 <MessagesSquare />
                 <Reddot count={newMailCount} />
             </button>

--- a/src/components/Myprofile.css
+++ b/src/components/Myprofile.css
@@ -1,26 +1,25 @@
 .profile-pic-container {
     position: relative;
-    width: 70%;           /* ✅ 부모의 70% 너비 */
-    aspect-ratio: 1 / 1; 
+    width: 70%; /* ✅ 부모의 70% 너비 */
+    aspect-ratio: 1 / 1;
     display: flex;
     justify-content: center;
     align-items: center;
     background: transparent;
-    overflow: hidden; 
-  }
-  
-  
-  /* 실제 프로필 이미지 */
-  .profile-pic {
+    overflow: hidden;
+}
+
+/* 실제 프로필 이미지 */
+.profile-pic {
     width: 100%;
     height: 100%;
     object-fit: cover;
     border-radius: 50%;
-     image-rendering: auto; /* 브라우저가 최적화 렌더링 결정 */
-  }
-  
-  /* 이미지 없을 경우 */
-  .profile-pic.empty {
+    image-rendering: auto; /* 브라우저가 최적화 렌더링 결정 */
+}
+
+/* 이미지 없을 경우 */
+.profile-pic.empty {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -31,10 +30,10 @@
     text-align: center;
     white-space: nowrap;
     border-radius: 50%;
-  }
-  
-  /* 카메라 아이콘 */
-  .camera-icon {
+}
+
+/* 카메라 아이콘 */
+.camera-icon {
     position: absolute;
     bottom: 5px;
     right: 5px;
@@ -46,12 +45,12 @@
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
     color: #555;
     cursor: pointer;
-  }
-  
-  /* 메뉴 */
-  .profile-menu {
+}
+
+/* 메뉴 */
+.profile-menu {
     position: absolute;
-    bottom: 40px;  /* 카메라 버튼 위에 살짝 뜨도록 조정 */
+    bottom: 40px; /* 카메라 버튼 위에 살짝 뜨도록 조정 */
     right: 0;
     background: white;
     border: 1px solid #ddd;
@@ -60,20 +59,20 @@
     z-index: 100;
     padding: 10px;
     width: 180px;
-  }
-  
-  .profile-menu div {
+}
+
+.profile-menu div {
     padding: 8px;
     cursor: pointer;
     font-size: 14px;
-  }
-  
-  .profile-menu div:hover {
+}
+
+.profile-menu div:hover {
     background-color: #f0f0f0;
-  }
-  
-  /* 모달 전체 영역 */
-  .modal-backdrop {
+}
+
+/* 모달 전체 영역 */
+.modal-backdrop {
     position: fixed;
     top: 0;
     left: 0;
@@ -85,27 +84,27 @@
     justify-content: center;
     align-items: center;
     z-index: 999;
-  }
-  
-  /* 프로필 이미지 확대 */
-  .modal-content {
+}
+
+/* 프로필 이미지 확대 */
+.modal-content {
     width: 300px;
     height: 300px;
     border-radius: 50%;
     overflow: hidden;
     box-shadow: 0 6px 30px rgba(0, 0, 0, 0.2);
     background-color: transparent;
-  }
-  
-  .modal-content img {
+}
+
+.modal-content img {
     width: 100%;
     height: 100%;
     object-fit: cover;
     border-radius: 50%;
-  }
-  
-  /* No Image 표시 */
-  .modal-empty {
+}
+
+/* No Image 표시 */
+.modal-empty {
     width: 100%;
     height: 100%;
     border-radius: 50%;
@@ -116,5 +115,4 @@
     align-items: center;
     justify-content: center;
     text-align: center;
-  }
-  
+}

--- a/src/components/Myprofile.jsx
+++ b/src/components/Myprofile.jsx
@@ -1,156 +1,184 @@
+import "./Myprofile.css";
+
 import { useState, useRef, useEffect, useContext } from "react";
 import { Camera } from "lucide-react";
-import "./Myprofile.css";
 import axiosInstance from "./utils/AxiosInstance";
 import { UserContext } from "./utils/UserContext";
 
 const MyProfile = ({ profileImageUrl }) => {
-  const [selectedImage, setSelectedImage] = useState(null);
-  const fileInputRef = useRef(null);
-  const [showProfileMenu, setShowProfileMenu] = useState(false);
-  const [showEditOptions, setShowEditOptions] = useState(false);
-  const [showProfileModal, setShowProfileModal] = useState(false);
-  const menuRef = useRef(null);
-  const { user, setUser } = useContext(UserContext);
+    const [selectedImage, setSelectedImage] = useState(null);
+    const fileInputRef = useRef(null);
+    const [showProfileMenu, setShowProfileMenu] = useState(false);
+    const [showEditOptions, setShowEditOptions] = useState(false);
+    const [showProfileModal, setShowProfileModal] = useState(false);
+    const menuRef = useRef(null);
+    const { user, setUser } = useContext(UserContext);
 
-  // 최초에 이미지 동기화 (user 정보 갱신된 후 처리)
-  useEffect(() => {
-    if (profileImageUrl) {
-      setSelectedImage(profileImageUrl);
-    }
-  }, [profileImageUrl]);
-
-  const toggleMenu = () => {
-    setShowProfileMenu((prev) => !prev);
-    setShowEditOptions(false);
-  };
-
-  const handleProfileView = () => {
-    setShowProfileModal(true);
-    setShowProfileMenu(false);
-  };
-
-  const handleFileChange = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-      const imageUrl = URL.createObjectURL(file);
-      setSelectedImage(imageUrl);
-      handleImageSelect(file);
-    }
-    setShowProfileMenu(false);
-    setShowEditOptions(false);
-  };
-
-  const openFilePicker = () => {
-    fileInputRef.current.click();
-  };
-
-  const handleDeleteImage = () => {
-    setSelectedImage(null);
-    handleImageSelect(null); // 삭제 요청
-    setShowProfileMenu(false);
-    setShowEditOptions(false);
-  };
-
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (menuRef.current && !menuRef.current.contains(event.target)) {
-        setShowProfileMenu(false);
-      }
-    };
-    if (showProfileMenu) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [showProfileMenu]);
-
-  const handleImageSelect = async (file) => {
-    const MAX_FILE_SIZE = 4 * 1024 * 1024;
-
-    try {
-      if (!file) {
-        const res = await axiosInstance.delete("/member/delete-profile-image");
-        if (res.data?.imageUrl) {
-          setUser((prev) => ({ ...prev, profileImageUrl: res.data.imageUrl }));
-          setSelectedImage(res.data.imageUrl);
+    // 최초에 이미지 동기화 (user 정보 갱신된 후 처리)
+    useEffect(() => {
+        const url = profileImageUrl ?? user?.profileImageUrl;
+        if (url) {
+            setSelectedImage(url);
         }
-        alert("프로필 이미지가 삭제되었습니다!");
-        return;
-      }
+    }, [profileImageUrl, user?.profileImageUrl]);
 
-      if (file.size > MAX_FILE_SIZE) {
-        alert("이미지 크기는 4MB 이하만 가능합니다.");
-        return;
-      }
+    const toggleMenu = () => {
+        setShowProfileMenu((prev) => !prev);
+        setShowEditOptions(false);
+    };
 
-      const formData = new FormData();
-      formData.append("profileImage", file);
+    const handleProfileView = () => {
+        setShowProfileModal(true);
+        setShowProfileMenu(false);
+    };
 
-      const res = await axiosInstance.post("/member/set-profile-image", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-      });
+    const handleFileChange = (event) => {
+        const file = event.target.files[0];
+        if (file) {
+            const imageUrl = URL.createObjectURL(file);
+            setSelectedImage(imageUrl);
+            handleImageSelect(file);
+        }
+        setShowProfileMenu(false);
+        setShowEditOptions(false);
+    };
 
-      if (res.data?.imageUrl) {
-        setUser((prev) => ({ ...prev, profileImageUrl: res.data.imageUrl }));
-        setSelectedImage(res.data.imageUrl);
-      }
+    const openFilePicker = () => {
+        fileInputRef.current.click();
+    };
 
-      alert("프로필 이미지가 저장되었습니다!");
-    } catch (err) {
-      console.error("프로필 이미지 업로드 실패:", err);
-      alert("프로필 이미지 저장에 실패했습니다.");
-    }
-  };
+    const handleDeleteImage = () => {
+        setSelectedImage(null);
+        handleImageSelect(null); // 삭제 요청
+        setShowProfileMenu(false);
+        setShowEditOptions(false);
+    };
 
-  return (
-    <div className="profile-pic-container">
-      {selectedImage ? (
-        <img className="profile-pic" src={selectedImage} alt="프로필" />
-      ) : (
-        <div className="profile-pic empty">No Image</div>
-      )}
+    useEffect(() => {
+        const handleClickOutside = (event) => {
+            if (menuRef.current && !menuRef.current.contains(event.target)) {
+                setShowProfileMenu(false);
+            }
+        };
+        if (showProfileMenu) {
+            document.addEventListener("mousedown", handleClickOutside);
+        }
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [showProfileMenu]);
 
-      <Camera className="camera-icon" onClick={toggleMenu} />
+    const handleImageSelect = async (file) => {
+        const MAX_FILE_SIZE = 4 * 1024 * 1024;
 
-      {showProfileMenu && (
-        <div className="profile-menu" ref={menuRef}>
-          {!showEditOptions ? (
-            <>
-              <div onClick={handleProfileView}>프로필 보기</div>
-              <div onClick={() => setShowEditOptions(true)}>프로필 수정</div>
-            </>
-          ) : (
-            <>
-              <div onClick={openFilePicker}>라이브러리에서 선택</div>
-              <div onClick={handleDeleteImage}>현재 사진 삭제</div>
-            </>
-          )}
-        </div>
-      )}
+        try {
+            if (!file) {
+                const res = await axiosInstance.delete(
+                    "/member/delete-profile-image"
+                );
+                if (res.data?.imageUrl) {
+                    setUser((prev) => ({
+                        ...prev,
+                        profileImageUrl: res.data.imageUrl,
+                    }));
+                    setSelectedImage(res.data.imageUrl);
+                }
+                alert("프로필 이미지가 삭제되었습니다!");
+                return;
+            }
 
-      <input
-        type="file"
-        accept="image/*"
-        ref={fileInputRef}
-        style={{ display: "none" }}
-        onChange={handleFileChange}
-      />
+            if (file.size > MAX_FILE_SIZE) {
+                alert("이미지 크기는 4MB 이하만 가능합니다.");
+                return;
+            }
 
-      {showProfileModal && (
-        <div className="modal-backdrop" onClick={() => setShowProfileModal(false)}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            const formData = new FormData();
+            formData.append("profileImage", file);
+
+            const res = await axiosInstance.post(
+                "/member/set-profile-image",
+                formData,
+                {
+                    headers: { "Content-Type": "multipart/form-data" },
+                }
+            );
+
+            if (res.data?.imageUrl) {
+                setUser((prev) => ({
+                    ...prev,
+                    profileImageUrl: res.data.imageUrl,
+                }));
+                setSelectedImage(res.data.imageUrl);
+            }
+
+            alert("프로필 이미지가 저장되었습니다!");
+        } catch (err) {
+            console.error("프로필 이미지 업로드 실패:", err);
+            alert("프로필 이미지 저장에 실패했습니다.");
+        }
+    };
+
+    return (
+        <div className="profile-pic-container">
             {selectedImage ? (
-              <img src={selectedImage} alt="프로필 확대" />
+                <img className="profile-pic" src={selectedImage} alt="프로필" />
             ) : (
-              <div className="profile-pic modal-empty">No Image</div>
+                <div className="profile-pic empty">No Image</div>
             )}
-          </div>
+
+            <Camera className="camera-icon" onClick={toggleMenu} />
+
+            {showProfileMenu && (
+                <div className="profile-menu" ref={menuRef}>
+                    {!showEditOptions ? (
+                        <>
+                            <div onClick={handleProfileView}>프로필 보기</div>
+                            <div onClick={() => setShowEditOptions(true)}>
+                                프로필 수정
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <div onClick={openFilePicker}>
+                                라이브러리에서 선택
+                            </div>
+                            <div onClick={handleDeleteImage}>
+                                현재 사진 삭제
+                            </div>
+                        </>
+                    )}
+                </div>
+            )}
+
+            <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                style={{ display: "none" }}
+                onChange={handleFileChange}
+            />
+
+            {showProfileModal && (
+                <div
+                    className="modal-backdrop"
+                    onClick={() => setShowProfileModal(false)}
+                >
+                    <div
+                        className="modal-content"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        {selectedImage ? (
+                            <img src={selectedImage} alt="프로필 확대" />
+                        ) : (
+                            <div className="profile-pic modal-empty">
+                                No Image
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
         </div>
-      )}
-    </div>
-  );
+    );
 };
 
 export default MyProfile;

--- a/src/components/Reddot.css
+++ b/src/components/Reddot.css
@@ -1,7 +1,7 @@
 .Reddot {
     background-color: var(--red-dot-color);
-    width: 16px !important;
-    height: 16px !important;
+    width: 16px;
+    height: 16px;
     position: absolute !important;
     display: flex;
     align-items: center;

--- a/src/components/Reddot.jsx
+++ b/src/components/Reddot.jsx
@@ -1,15 +1,13 @@
-import "./Reddot.css"
-const Reddot = ({count})=>{
+import "./Reddot.css";
+
+const Reddot = ({ count }) => {
     if (count === 0) return null;
 
-    return(
+    return (
         <div className="Reddot">
-                <div className="content">
-                    {count}
-                </div>
+            <div className="content">{count}</div>
         </div>
-    )
+    );
+};
 
-}
-
-export default Reddot
+export default Reddot;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,70 +1,71 @@
-import { X, User, Bell, Mail, LogOut, Shield } from "lucide-react";
 import "./Sidebar.css";
+
+import { X, User, Mail, LogOut, Shield } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom"; // ✅ 추가
 
 const Sidebar = ({ isOpen, onClose }) => {
-  const navigate = useNavigate();
+    const navigate = useNavigate();
 
-  const handleLogout = () => {
-    localStorage.clear();
-    navigate("/login");
-  };
+    const handleLogout = () => {
+        localStorage.clear();
+        navigate("/login");
+    };
 
-  return (
-    <>
-      <div className={`sidebar ${isOpen ? "open" : ""}`}>
-        <div className="close-area">
-          <button
-            className="close-btn"
-            onClick={onClose}
-            aria-label="Close sidebar"
-          >
-            <X size={30} />
-          </button>
-        </div>
+    return (
+        <>
+            <div className={`sidebar ${isOpen ? "open" : ""}`}>
+                <div className="close-area">
+                    <button
+                        className="close-btn"
+                        onClick={onClose}
+                        aria-label="Close sidebar"
+                    >
+                        <X size={30} />
+                    </button>
+                </div>
 
-        <div className="content-area">
-          <ul className="sidebar-menu">
-            {/* ✅ 마이페이지 */}
-            <li onClick={onClose}>
-              <Link to="/mypage" className="sidebar-link">
-                <User size={18} />
-                <span>마이페이지</span>
-              </Link>
-            </li>
+                <div className="content-area">
+                    <ul className="sidebar-menu">
+                        {/* ✅ 마이페이지 */}
+                        <li onClick={onClose}>
+                            <Link to="/mypage" className="sidebar-link">
+                                <User size={18} />
+                                <span>마이페이지</span>
+                            </Link>
+                        </li>
 
-            {/* ✅ 관리자 페이지 */}
-            <li onClick={onClose}>
-              <Link to="/admin" className="sidebar-link">
-                <Shield size={18} />
-                <span>관리자 페이지</span>
-              </Link>
-            </li>
+                        {/* ✅ 관리자 페이지 */}
+                        <li onClick={onClose}>
+                            <Link to="/admin" className="sidebar-link">
+                                <Shield size={18} />
+                                <span>관리자 페이지</span>
+                            </Link>
+                        </li>
 
-            {/* ✅ 메일함 (chat-mail) */}
-            <li onClick={onClose}>
-              <Link to="/chat-mail" className="sidebar-link">
-                <Mail size={18} />
-                <span>메일함</span>
-              </Link>
-            </li>
+                        {/* ✅ 메일함 (chat-mail) */}
+                        <li onClick={onClose}>
+                            <Link to="/chat-mail" className="sidebar-link">
+                                <Mail size={18} />
+                                <span>메일함</span>
+                            </Link>
+                        </li>
 
-            {/* 로그아웃 */}
-            <li onClick={handleLogout}>
-              <LogOut size={18} />
-              <span>로그아웃</span>
-            </li>
-          </ul>
-        </div>
-      </div>
+                        {/* 로그아웃 */}
+                        <li onClick={handleLogout}>
+                            <LogOut size={18} />
+                            <span>로그아웃</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
 
-      {/* 백드롭 클릭 시 닫힘 */}
-      <div
-        className={`sidebar-backdrop ${isOpen ? "show" : ""}`}
-        onClick={onClose}
-      />
-    </>
-  );
+            {/* 백드롭 클릭 시 닫힘 */}
+            <div
+                className={`sidebar-backdrop ${isOpen ? "show" : ""}`}
+                onClick={onClose}
+            />
+        </>
+    );
 };
 
 export default Sidebar;

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,9 @@ body {
     font-size: var(--font-size-base);
 }
 
-* {
+*,
+*::before,
+*::after {
     margin: 0;
     padding: 0;
     box-sizing: border-box;

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -9,54 +9,63 @@ import MarketUploadModal from "../components/board-box/MarketUploadModal";
 import "./BoardPage.css";
 
 const BoardPage = () => {
-  const { boardType } = useParams();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const isPostDetail = location.pathname.includes("/post/");
-  const [showUploadModal, setShowUploadModal] = useState(false);
+    const { boardType } = useParams();
+    const navigate = useNavigate();
+    const location = useLocation();
+    const isPostDetail = location.pathname.includes("/post/");
+    const [showUploadModal, setShowUploadModal] = useState(false);
 
-  const renderBoard = () => {
-    switch (boardType) {
-      case "free":
-      case "notice_c":
-      case "notice":
-      case "secret":
-      case "review":
-        return <BasicBoardBox boardType={boardType} handleWriteClick = {handleWriteClick} />;
-      case "market":
-        return <MarketBox boardType={boardType} setShowUploadModal={setShowUploadModal}/>;
-      case "popular":
-        return <div>인기게시판 컴포넌트</div>;
-      default:
-        return <div>존재하지 않는 게시판입니다.</div>;
-    }
-  };
+    const renderBoard = () => {
+        switch (boardType) {
+            case "free":
+            case "notice_c":
+            case "notice":
+            case "secret":
+            case "review":
+                return (
+                    <BasicBoardBox
+                        boardType={boardType}
+                        handleWriteClick={handleWriteClick}
+                    />
+                );
+            case "market":
+                return (
+                    <MarketBox
+                        boardType={boardType}
+                        setShowUploadModal={setShowUploadModal}
+                    />
+                );
+            case "popular":
+                return <div>인기게시판 컴포넌트</div>;
+            default:
+                return <div>존재하지 않는 게시판입니다.</div>;
+        }
+    };
 
-  const handleWriteClick = () => {
-    navigate(`/write/${boardType}`);
-  };
+    const handleWriteClick = () => {
+        navigate(`/write/${boardType}`);
+    };
 
+    return (
+        <div className="BoardPage">
+            <div className="header-with-button">
+                <Header />
+            </div>
 
-  return (
-    <div className="BoardPage">
-      <div className="header-with-button">
-        <Header title={"게시판"} />
-      </div>
+            <div className="layout-container">
+                <div className="content-container">
+                    <div className="board-container">
+                        {isPostDetail ? <PostDetail /> : renderBoard()}
+                    </div>
+                </div>
+            </div>
 
-      <div className="layout-container">
-        <div className="content-container">
-          <div className="board-container">
-            {isPostDetail ? <PostDetail /> : renderBoard()}
-          </div>
+            {/* 모달 렌더링 */}
+            {showUploadModal && (
+                <MarketUploadModal onClose={() => setShowUploadModal(false)} />
+            )}
         </div>
-      </div>
-
-      {/* 모달 렌더링 */}
-      {showUploadModal && (
-        <MarketUploadModal onClose={() => setShowUploadModal(false)} />
-      )}
-    </div>
-  );
+    );
 };
 
 export default BoardPage;

--- a/src/pages/LectureBoardPage.jsx
+++ b/src/pages/LectureBoardPage.jsx
@@ -1,4 +1,4 @@
-// 해당 강의 페이지 
+// 해당 강의 페이지
 import Header from "../components/Header";
 import { useParams, useNavigate } from "react-router-dom";
 import "./LectureBoardPage.css";
@@ -11,200 +11,234 @@ import { Star } from "lucide-react";
 const tabList = ["질문", "후기", "자료실", "공지사항"];
 
 const tabToTypeMap = {
-  질문: "LECTURE_Q",
-  후기: "LECTURE_R",
-  자료실: "LECTURE_REF",
-  공지사항: "LECTURE_N"
+    질문: "LECTURE_Q",
+    후기: "LECTURE_R",
+    자료실: "LECTURE_REF",
+    공지사항: "LECTURE_N",
 };
 
 const LectureBoardPage = () => {
-  const { lectureId } = useParams();
-  const navigate = useNavigate();
+    const { lectureId } = useParams();
+    const navigate = useNavigate();
 
-  const [lecture, setLecture] = useState(null);
-  const [selectedTab, setSelectedTab] = useState("질문");
-  const [posts, setPosts] = useState([]);
-  const [weeklyStats, setWeeklyStats] = useState({ 질문: 0, 후기: 0, 자료실: 0, 공지사항: 0 });
-  const [cheerMessage, setCheerMessage] = useState("");
-  const [fade, setFade] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [isMarked, setIsMarked] = useState(false); // ✅ 변수 통일
+    const [lecture, setLecture] = useState(null);
+    const [selectedTab, setSelectedTab] = useState("질문");
+    const [posts, setPosts] = useState([]);
+    const [weeklyStats, setWeeklyStats] = useState({
+        질문: 0,
+        후기: 0,
+        자료실: 0,
+        공지사항: 0,
+    });
+    const [cheerMessage, setCheerMessage] = useState("");
+    const [fade, setFade] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [isMarked, setIsMarked] = useState(false); // ✅ 변수 통일
 
-  useEffect(() => {
-    const fetchLecture = async () => {
-      try {
-        const res = await axiosInstance.get(`/lecture-room/${lectureId}`);
-        setLecture(res.data.data);
-        setIsMarked(res.data.data.isMarked); // ✅ 응답 값에서 바로 반영
-      } catch (err) {
-        console.error("강의 정보 불러오기 실패", err);
-        setError("강의 정보를 불러올 수 없습니다.");
-      } finally {
-        setLoading(false);
-      }
+    useEffect(() => {
+        const fetchLecture = async () => {
+            try {
+                const res = await axiosInstance.get(
+                    `/lecture-room/${lectureId}`
+                );
+                setLecture(res.data.data);
+                setIsMarked(res.data.data.isMarked); // ✅ 응답 값에서 바로 반영
+            } catch (err) {
+                console.error("강의 정보 불러오기 실패", err);
+                setError("강의 정보를 불러올 수 없습니다.");
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchLecture();
+    }, [lectureId]);
+
+    const toggleFavorite = async () => {
+        try {
+            if (isMarked) {
+                await axiosInstance.delete("/lecture-room/mark", {
+                    params: { lectureRoomId: lectureId },
+                });
+            } else {
+                await axiosInstance.post("/lecture-room/mark", null, {
+                    params: { lectureRoomId: lectureId },
+                });
+            }
+
+            setIsMarked(!isMarked);
+            window.dispatchEvent(new Event("favoritesUpdated")); // ✅ 외부 컴포넌트 갱신용
+        } catch (e) {
+            console.error("❌ 즐겨찾기 변경 실패", e);
+            console.error(
+                "🔍 서버 응답 내용:",
+                e.response?.data || "(응답 없음)"
+            );
+        }
     };
-    fetchLecture();
-  }, [lectureId]);
 
-  const toggleFavorite = async () => {
-    try {
-      if (isMarked) {
-        await axiosInstance.delete("/lecture-room/mark", {
-          params: { lectureRoomId: lectureId },
-        });
-      } else {
-        await axiosInstance.post("/lecture-room/mark", null, {
-          params: { lectureRoomId: lectureId },
-        });
-      }
+    useEffect(() => {
+        const fetchPosts = async () => {
+            try {
+                const postType = tabToTypeMap[selectedTab];
+                const res = await axiosInstance.get("/lecture-room/posts", {
+                    params: { lectureId, type: postType },
+                });
+                setPosts(res.data.data);
+            } catch (err) {
+                console.error("게시글 불러오기 실패", err);
+                setPosts([]);
+            }
+        };
+        fetchPosts();
+    }, [selectedTab, lectureId]);
 
-      setIsMarked(!isMarked);
-      window.dispatchEvent(new Event("favoritesUpdated")); // ✅ 외부 컴포넌트 갱신용
-    } catch (e) {
-      console.error("❌ 즐겨찾기 변경 실패", e);
-      console.error("🔍 서버 응답 내용:", e.response?.data || "(응답 없음)");
-    }
-  };
+    useEffect(() => {
+        const quotes = [
+            "성공은 작은 노력들이 반복될 때 이루어진다. – 로버트 콜리어",
+            "지금 하는 일이 미래를 만든다. – 마하트마 간디",
+            "할 수 있다고 믿으면 이미 반은 이룬 것이다. – 시어도어 루스벨트",
+            "행동은 모든 성공의 기초다. – 파블로 피카소",
+            "오늘 걷지 않으면 내일 뛰어야 한다. – 한국 속담",
+        ];
+        const changeQuote = () => {
+            setFade(false);
+            setTimeout(() => {
+                const random =
+                    quotes[Math.floor(Math.random() * quotes.length)];
+                setCheerMessage(random);
+                setFade(true);
+            }, 300);
+        };
+        changeQuote();
+        const interval = setInterval(changeQuote, 6000);
+        return () => clearInterval(interval);
+    }, []);
 
-  useEffect(() => {
-    const fetchPosts = async () => {
-      try {
-        const postType = tabToTypeMap[selectedTab];
-        const res = await axiosInstance.get("/lecture-room/posts", {
-          params: { lectureId, type: postType },
-        });
-        setPosts(res.data.data);
-      } catch (err) {
-        console.error("게시글 불러오기 실패", err);
-        setPosts([]);
-      }
-    };
-    fetchPosts();
-  }, [selectedTab, lectureId]);
-
-  useEffect(() => {
-    const quotes = [
-      "성공은 작은 노력들이 반복될 때 이루어진다. – 로버트 콜리어",
-      "지금 하는 일이 미래를 만든다. – 마하트마 간디",
-      "할 수 있다고 믿으면 이미 반은 이룬 것이다. – 시어도어 루스벨트",
-      "행동은 모든 성공의 기초다. – 파블로 피카소",
-      "오늘 걷지 않으면 내일 뛰어야 한다. – 한국 속담",
-    ];
-    const changeQuote = () => {
-      setFade(false);
-      setTimeout(() => {
-        const random = quotes[Math.floor(Math.random() * quotes.length)];
-        setCheerMessage(random);
-        setFade(true);
-      }, 300);
-    };
-    changeQuote();
-    const interval = setInterval(changeQuote, 6000);
-    return () => clearInterval(interval);
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="LectureBoardPage">
-        <div style={{ padding: "40px" }}>
-          <h2>로딩 중...</h2>
-        </div>
-      </div>
-    );
-  }
-
-  if (error || !lecture) {
-    return (
-      <div className="LectureBoardPage">
-        <div style={{ padding: "40px" }}>
-          <h2>❌ 강의 정보를 불러올 수 없습니다.</h2>
-          <p>lectureId: {lectureId}</p>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="LectureBoardPage">
-      <Header title="강의 게시판" />  {/* ✅ Header 추가 */}
-      <div className="lecture-board-container">
-        <div className="lecture-main-content">
-          <div className="lecture-header">
-            <div className="lecture-title-wrapper">
-              <button className="Lecture-Favorite-Button" onClick={toggleFavorite}>
-                <Star
-                  size={22}
-                  stroke="black"
-                  fill={isMarked ? "gold" : "none"}
-                  style={{ marginLeft: "6px" }}
-                />
-              </button>
-              <h2 className="lecture-title">{lecture.title}</h2>
-              <ProfileTemplate
-                profileImageUrl={lecture.professorThumbnail}
-                name={lecture.professorNickname}
-                id={lecture.professorId}
-              />
-              <span className="lecture-professor">{lecture.professorName} 교수님</span>
+    if (loading) {
+        return (
+            <div className="LectureBoardPage">
+                <div style={{ padding: "40px" }}>
+                    <h2>로딩 중...</h2>
+                </div>
             </div>
-          </div>
+        );
+    }
 
-          <div className="content-container">
-            <section className="main-area">
-              <div className="tab-and-write-row">
-                <div className="tab-buttons">
-                  {tabList.map((tab) => (
-                    <button
-                      key={tab}
-                      className={`tab-button ${selectedTab === tab ? "active-tab" : ""}`}
-                      onClick={() => setSelectedTab(tab)}
-                    >
-                      {tab}
-                    </button>
-                  ))}
-                  <button
-                    className="lecture-write-button"
-                    onClick={() => navigate(`/main/study-dashboard/${lectureId}/write`)}
-                  >
-                    글쓰기
-                  </button>
+    if (error || !lecture) {
+        return (
+            <div className="LectureBoardPage">
+                <div style={{ padding: "40px" }}>
+                    <h2>❌ 강의 정보를 불러올 수 없습니다.</h2>
+                    <p>lectureId: {lectureId}</p>
                 </div>
-              </div>
-              {posts.length === 0 ? (
-                <p className="no-posts">게시글이 없습니다.</p>
-              ) : (
-                posts.map((post) => <PostPreviewBox key={post.id} post={post} />)
-              )}
-            </section>
+            </div>
+        );
+    }
 
-            <aside className="lecture-sidebar">
-              <div className="dday-box">
-                <div className="dday-header">
-                  <div className="dday-left">
-                    <div className="dday-name">오늘의 명언</div>
-                    <div className={`dday-message ${fade ? "fade-in" : "fade-out"}`}>
-                      {cheerMessage}
+    return (
+        <div className="LectureBoardPage">
+            <Header />
+            <div className="lecture-board-container">
+                <div className="lecture-main-content">
+                    <div className="lecture-header">
+                        <div className="lecture-title-wrapper">
+                            <button
+                                className="Lecture-Favorite-Button"
+                                onClick={toggleFavorite}
+                            >
+                                <Star
+                                    size={22}
+                                    stroke="black"
+                                    fill={isMarked ? "gold" : "none"}
+                                    style={{ marginLeft: "6px" }}
+                                />
+                            </button>
+                            <h2 className="lecture-title">{lecture.title}</h2>
+                            <ProfileTemplate
+                                profileImageUrl={lecture.professorThumbnail}
+                                name={lecture.professorNickname}
+                                id={lecture.professorId}
+                            />
+                            <span className="lecture-professor">
+                                {lecture.professorName} 교수님
+                            </span>
+                        </div>
                     </div>
-                  </div>
-                </div>
-              </div>
 
-              <div className="activity-box">
-                <h4>이번주 활동</h4>
-                <ul>
-                  <li>질문 {weeklyStats["질문"]}건</li>
-                  <li>후기 {weeklyStats["후기"]}건</li>
-                  <li>자료실 {weeklyStats["자료실"]}건</li>
-                  <li>공지사항 {weeklyStats["공지사항"]}건</li>
-                </ul>
-              </div>
-            </aside>
-          </div>
+                    <div className="content-container">
+                        <section className="main-area">
+                            <div className="tab-and-write-row">
+                                <div className="tab-buttons">
+                                    {tabList.map((tab) => (
+                                        <button
+                                            key={tab}
+                                            className={`tab-button ${
+                                                selectedTab === tab
+                                                    ? "active-tab"
+                                                    : ""
+                                            }`}
+                                            onClick={() => setSelectedTab(tab)}
+                                        >
+                                            {tab}
+                                        </button>
+                                    ))}
+                                    <button
+                                        className="lecture-write-button"
+                                        onClick={() =>
+                                            navigate(
+                                                `/main/study-dashboard/${lectureId}/write`
+                                            )
+                                        }
+                                    >
+                                        글쓰기
+                                    </button>
+                                </div>
+                            </div>
+                            {posts.length === 0 ? (
+                                <p className="no-posts">게시글이 없습니다.</p>
+                            ) : (
+                                posts.map((post) => (
+                                    <PostPreviewBox key={post.id} post={post} />
+                                ))
+                            )}
+                        </section>
+
+                        <aside className="lecture-sidebar">
+                            <div className="dday-box">
+                                <div className="dday-header">
+                                    <div className="dday-left">
+                                        <div className="dday-name">
+                                            오늘의 명언
+                                        </div>
+                                        <div
+                                            className={`dday-message ${
+                                                fade ? "fade-in" : "fade-out"
+                                            }`}
+                                        >
+                                            {cheerMessage}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="activity-box">
+                                <h4>이번주 활동</h4>
+                                <ul>
+                                    <li>질문 {weeklyStats["질문"]}건</li>
+                                    <li>후기 {weeklyStats["후기"]}건</li>
+                                    <li>자료실 {weeklyStats["자료실"]}건</li>
+                                    <li>
+                                        공지사항 {weeklyStats["공지사항"]}건
+                                    </li>
+                                </ul>
+                            </div>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  );
+    );
 };
 
 export default LectureBoardPage;

--- a/src/pages/MailPage.jsx
+++ b/src/pages/MailPage.jsx
@@ -50,9 +50,12 @@ const MailPage = () => {
 
         try {
             const params = beforeId ? { beforeId, size: 20 } : { size: 20 };
-            const response = await axiosInstance.get(`/mail/messages/${roomId}`, {
-                params,
-            });
+            const response = await axiosInstance.get(
+                `/mail/messages/${roomId}`,
+                {
+                    params,
+                }
+            );
 
             if (response.status === 200 && response.data.messages) {
                 const ordered = response.data.messages.reverse();
@@ -108,7 +111,7 @@ const MailPage = () => {
 
     return (
         <div className="MailPage">
-            <Header title="Chat-mail" />
+            <Header />
             <div className="layout">
                 <aside className="mail-side">
                     <MailSide

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -14,12 +14,13 @@ const MyPage = () => {
     const [nickname, setNickname] = useState("");
     const [nicknameError, setNicknameError] = useState("");
     const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
-    const [isPasswordEditModalOpen, setIsPasswordEditModalOpen] = useState(false);
+    const [isPasswordEditModalOpen, setIsPasswordEditModalOpen] =
+        useState(false);
     const [isEmailModalOpen, setIsEmailModalOpen] = useState(false); // ★
-    const [isConfirmingEmailChange, setIsConfirmingEmailChange] = useState(false);
+    const [isConfirmingEmailChange, setIsConfirmingEmailChange] =
+        useState(false);
     const { user, setUser } = useContext(UserContext);
     const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
-
 
     useEffect(() => {
         if (user) {
@@ -50,8 +51,13 @@ const MyPage = () => {
         const MAX_FILE_SIZE = 4 * 1024 * 1024;
         try {
             if (!file) {
-                const res = await axiosInstance.delete("/member/delete-profile-image");
-                setUser((prev) => ({ ...prev, profileImageUrl: res.data.imageUrl }));
+                const res = await axiosInstance.delete(
+                    "/member/delete-profile-image"
+                );
+                setUser((prev) => ({
+                    ...prev,
+                    profileImageUrl: res.data.imageUrl,
+                }));
                 alert("프로필 이미지가 삭제되었습니다!");
                 return;
             }
@@ -61,10 +67,17 @@ const MyPage = () => {
             }
             const formData = new FormData();
             formData.append("profileImage", file);
-            const res = await axiosInstance.post("/member/set-profile-image", formData, {
-                headers: { "Content-Type": "multipart/form-data" },
-            });
-            setUser((prev) => ({ ...prev, profileImageUrl: res.data.imageUrl }));
+            const res = await axiosInstance.post(
+                "/member/set-profile-image",
+                formData,
+                {
+                    headers: { "Content-Type": "multipart/form-data" },
+                }
+            );
+            setUser((prev) => ({
+                ...prev,
+                profileImageUrl: res.data.imageUrl,
+            }));
             alert("프로필 이미지가 저장되었습니다!");
         } catch (err) {
             console.error("프로필 이미지 업로드 실패:", err);
@@ -76,11 +89,14 @@ const MyPage = () => {
 
     return (
         <div className="MyPage">
-            <Header title="Mypage" />
+            <Header />
             <div className="page-container">
                 <aside className="profile-section">
                     <div className="proflie-img-box">
-                        <MyProfile profileImageUrl={user.profileImageUrl} onImageSelect={handleImageSelect} />
+                        <MyProfile
+                            profileImageUrl={user.profileImageUrl}
+                            onImageSelect={handleImageSelect}
+                        />
                     </div>
                     <div className="profile-info">
                         <label>닉네임: {nickname} </label>
@@ -97,33 +113,59 @@ const MyPage = () => {
                             }}
                         />
                         {nicknameError && (
-                            <small style={{ color: "red", marginTop: "4px", display: "block" }}>
+                            <small
+                                style={{
+                                    color: "red",
+                                    marginTop: "4px",
+                                    display: "block",
+                                }}
+                            >
                                 {nicknameError}
                             </small>
                         )}
-                        <button className="save-btn" onClick={async () => {
-                            const trimmed = nickname.trim();
-                            if (!isValidNickname(trimmed)) {
-                                setNicknameError("닉네임은 10자 이하, 공백/특수문자 불가입니다.");
-                                setNickname(user.nickname || "");
-                                return;
-                            }
-                            try {
-                                const res = await axiosInstance.post("/member/set-nickname", { nickname: trimmed });
-                                if (res.status === 200) {
-                                    setUser((prev) => ({ ...prev, nickname: trimmed }));
-                                    alert("닉네임이 저장되었습니다!");
+                        <button
+                            className="save-btn"
+                            onClick={async () => {
+                                const trimmed = nickname.trim();
+                                if (!isValidNickname(trimmed)) {
+                                    setNicknameError(
+                                        "닉네임은 10자 이하, 공백/특수문자 불가입니다."
+                                    );
+                                    setNickname(user.nickname || "");
+                                    return;
                                 }
-                            } catch (error) {
-                                setNickname(user.nickname || "");
-                                if (error.response?.status === 409) {
-                                    setNicknameError("이미 사용 중인 닉네임입니다.");
-                                } else {
-                                    console.error("닉네임 저장 실패:", error);
-                                    setNicknameError("닉네임 저장에 실패했습니다.");
+                                try {
+                                    const res = await axiosInstance.post(
+                                        "/member/set-nickname",
+                                        { nickname: trimmed }
+                                    );
+                                    if (res.status === 200) {
+                                        setUser((prev) => ({
+                                            ...prev,
+                                            nickname: trimmed,
+                                        }));
+                                        alert("닉네임이 저장되었습니다!");
+                                    }
+                                } catch (error) {
+                                    setNickname(user.nickname || "");
+                                    if (error.response?.status === 409) {
+                                        setNicknameError(
+                                            "이미 사용 중인 닉네임입니다."
+                                        );
+                                    } else {
+                                        console.error(
+                                            "닉네임 저장 실패:",
+                                            error
+                                        );
+                                        setNicknameError(
+                                            "닉네임 저장에 실패했습니다."
+                                        );
+                                    }
                                 }
-                            }
-                        }}>저장</button>
+                            }}
+                        >
+                            저장
+                        </button>
                         <br />
                         <label>자기소개: </label>
                         <textarea
@@ -132,8 +174,12 @@ const MyPage = () => {
                             maxLength={200}
                             onChange={(e) => setIntro(e.target.value)}
                         />
-                        <small style={{ color: "gray" }}>{intro.length}/200자</small>
-                        <button className="save-btn" onClick={handleSave}>저장</button>
+                        <small style={{ color: "gray" }}>
+                            {intro.length}/200자
+                        </small>
+                        <button className="save-btn" onClick={handleSave}>
+                            저장
+                        </button>
                     </div>
                 </aside>
 
@@ -141,9 +187,14 @@ const MyPage = () => {
                     <div className="section-card">
                         <h3>계정</h3>
                         <ul>
-                            <li>학번 <span>{user.username}</span></li>
+                            <li>
+                                학번 <span>{user.username}</span>
+                            </li>
                             <li>졸업생 전환</li>
-                            <li className="interactive-item" onClick={() => setIsPasswordModalOpen(true)}>
+                            <li
+                                className="interactive-item"
+                                onClick={() => setIsPasswordModalOpen(true)}
+                            >
                                 비밀번호 변경
                             </li>
                             <li

--- a/src/pages/MyPageV2.jsx
+++ b/src/pages/MyPageV2.jsx
@@ -15,7 +15,11 @@ const MyPageV2 = () => {
     const [isPasswordVerified, setIsPasswordVerified] = useState(false);
 
     if (!user) {
-        return <div className="mypage-loading">유저 정보를 불러오는 중입니다...</div>;
+        return (
+            <div className="mypage-loading">
+                유저 정보를 불러오는 중입니다...
+            </div>
+        );
     }
 
     const handleSecureNavigate = (route, focusSection = null) => {
@@ -34,7 +38,7 @@ const MyPageV2 = () => {
 
     return (
         <div className="Mypage">
-            <Header title="Mypage" />
+            <Header />
             <div className="out-layout">
                 <div className="container">
                     <aside>
@@ -48,8 +52,28 @@ const MyPageV2 = () => {
                                 <h3>내 활동</h3>
                                 <ul>
                                     <li>좋아요 한 게시물</li>
-                                    <li onClick={() => navigate("activity", { state: { focusSection: "comments" } })}>작성한 댓글</li>
-                                    <li onClick={() => navigate("activity", { state: { focusSection: "posts" } })}>작성한 글</li>
+                                    <li
+                                        onClick={() =>
+                                            navigate("activity", {
+                                                state: {
+                                                    focusSection: "comments",
+                                                },
+                                            })
+                                        }
+                                    >
+                                        작성한 댓글
+                                    </li>
+                                    <li
+                                        onClick={() =>
+                                            navigate("activity", {
+                                                state: {
+                                                    focusSection: "posts",
+                                                },
+                                            })
+                                        }
+                                    >
+                                        작성한 글
+                                    </li>
                                     <li>이용 제한 내역</li>
                                 </ul>
                             </div>
@@ -58,10 +82,28 @@ const MyPageV2 = () => {
                                 <h3>계정 및 보안</h3>
                                 <ul>
                                     {/* 개인정보 수정 클릭 시 account 컴포넌트로 가면서 focus info */}
-                                    <li onClick={() => handleSecureNavigate("account", "info")}>개인 정보 수정</li>
+                                    <li
+                                        onClick={() =>
+                                            handleSecureNavigate(
+                                                "account",
+                                                "info"
+                                            )
+                                        }
+                                    >
+                                        개인 정보 수정
+                                    </li>
                                     <li>커뮤니티 이용규칙</li>
                                     {/* 계정 클릭 시 account 컴포넌트로 가면서 focus security */}
-                                    <li onClick={() => handleSecureNavigate("account", "security")}>계정</li>
+                                    <li
+                                        onClick={() =>
+                                            handleSecureNavigate(
+                                                "account",
+                                                "security"
+                                            )
+                                        }
+                                    >
+                                        계정
+                                    </li>
                                 </ul>
                             </div>
                         </div>
@@ -83,8 +125,13 @@ const MyPageV2 = () => {
                         setIsPasswordModalOpen(false);
                         setIsPasswordVerified(true);
                         if (pendingRoute) {
-                            if (pendingRoute === "account" && pendingRouteFocus) {
-                                navigate(pendingRoute, { state: { focusSection: pendingRouteFocus } });
+                            if (
+                                pendingRoute === "account" &&
+                                pendingRouteFocus
+                            ) {
+                                navigate(pendingRoute, {
+                                    state: { focusSection: pendingRouteFocus },
+                                });
                             } else {
                                 navigate(pendingRoute);
                             }

--- a/src/pages/StudyDashboardPage.jsx
+++ b/src/pages/StudyDashboardPage.jsx
@@ -7,47 +7,47 @@ import LectureCategoryBox from "../components/board-box/LectureCategoryBox";
 import "./StudyDashboardPage.css";
 
 const StudyDashboardPage = () => {
-  const [credit, setCredit] = useState(0);
-  const [isLectureBoxVisible, setIsLectureBoxVisible] = useState(false); // ✅ 강의목록 표시 여부
+    const [credit, setCredit] = useState(0);
+    const [isLectureBoxVisible, setIsLectureBoxVisible] = useState(false); // ✅ 강의목록 표시 여부
 
-  const handleCreditChange = (newCredit) => {
-    setCredit(newCredit);
-  };
+    const handleCreditChange = (newCredit) => {
+        setCredit(newCredit);
+    };
 
-  const toggleLectureBox = () => {
-    setIsLectureBoxVisible(!isLectureBoxVisible);
-  };
+    const toggleLectureBox = () => {
+        setIsLectureBoxVisible(!isLectureBoxVisible);
+    };
 
-  return (
-    <div className="StudyDashboardPage">
-      <Header title={"시간표"} />
-      <div className="DashboardLayout">
-        <div className="TimetableSection">
-          <Timetable onCreditChange={handleCreditChange} />
-        </div>
-        <div className="SidePanelSection">
-          <select className="SemesterSelect">
-            <option>2025년 2학기</option>
-          </select>
-          <div className="CreditInfoBox">
-            <div className="Title">시간표</div>
-            <div className="SubInfo">
-              <span className="Credit">{credit} 학점</span>
+    return (
+        <div className="StudyDashboardPage">
+            <Header />
+            <div className="DashboardLayout">
+                <div className="TimetableSection">
+                    <Timetable onCreditChange={handleCreditChange} />
+                </div>
+                <div className="SidePanelSection">
+                    <select className="SemesterSelect">
+                        <option>2025년 2학기</option>
+                    </select>
+                    <div className="CreditInfoBox">
+                        <div className="Title">시간표</div>
+                        <div className="SubInfo">
+                            <span className="Credit">{credit} 학점</span>
+                        </div>
+                    </div>
+                    <StudyNavi onToggleLectureBox={toggleLectureBox} />
+                </div>
+                <div className="ContentSection">
+                    <Outlet />
+                </div>
             </div>
-          </div>
-          <StudyNavi onToggleLectureBox={toggleLectureBox} /> 
+            {isLectureBoxVisible && (
+                <div className="BottomLectureBox">
+                    <LectureCategoryBox />
+                </div>
+            )}
         </div>
-        <div className="ContentSection">
-          <Outlet />
-        </div>
-      </div>
-      {isLectureBoxVisible && (
-        <div className="BottomLectureBox">
-          <LectureCategoryBox />
-        </div>
-      )}
-    </div>
-  );
+    );
 };
 
 export default StudyDashboardPage;

--- a/src/pages/WritePage.jsx
+++ b/src/pages/WritePage.jsx
@@ -7,11 +7,11 @@ import { getBoardLabel } from "../components/utils/boardUtils";
 
 import "./WritePage.css";
 import {
-  FileImage,
-  Paperclip,
-  Link as LinkIcon,
-  AArrowUp,
-  AArrowDown,
+    FileImage,
+    Paperclip,
+    Link as LinkIcon,
+    AArrowUp,
+    AArrowDown,
 } from "lucide-react";
 
 const WritePage = () => {
@@ -58,47 +58,47 @@ const WritePage = () => {
     }
   }, [isEditMode, postId, selectedBoard]);
 
-  const applyStyle = (command) => {
-    document.execCommand(command, false, null);
-    editorRef.current.focus();
-  };
+    const applyStyle = (command) => {
+        document.execCommand(command, false, null);
+        editorRef.current.focus();
+    };
 
-  const insertHTML = (html) => {
-    editorRef.current.focus();
-    document.execCommand("insertHTML", false, html);
-  };
+    const insertHTML = (html) => {
+        editorRef.current.focus();
+        document.execCommand("insertHTML", false, html);
+    };
 
-  const handleImageUpload = async (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
+    const handleImageUpload = async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
 
-    try {
-      const res = await axiosInstance.get("/aws/S3/presign", {
-        params: { filename: file.name, contentType: file.type },
-      });
-      const { uploadUrl, fileUrl } = res.data;
+        try {
+            const res = await axiosInstance.get("/aws/S3/presign", {
+                params: { filename: file.name, contentType: file.type },
+            });
+            const { uploadUrl, fileUrl } = res.data;
 
-      await axios.put(uploadUrl, file, {
-        headers: {
-          "Content-Type": file.type,
-          Authorization: undefined,
-        },
-      });
+            await axios.put(uploadUrl, file, {
+                headers: {
+                    "Content-Type": file.type,
+                    Authorization: undefined,
+                },
+            });
 
-      const imgTag = `<img src="${fileUrl}" alt="${file.name}" style="max-width: 500px; width: 100%; height: auto; margin: 8px 0;" />`;
-      insertHTML(imgTag);
-    } catch (err) {
-      console.error("❌ 이미지 업로드 실패:", err);
-      alert("이미지 업로드 실패: 콘솔 로그를 확인하세요.");
-    }
-  };
+            const imgTag = `<img src="${fileUrl}" alt="${file.name}" style="max-width: 500px; width: 100%; height: auto; margin: 8px 0;" />`;
+            insertHTML(imgTag);
+        } catch (err) {
+            console.error("❌ 이미지 업로드 실패:", err);
+            alert("이미지 업로드 실패: 콘솔 로그를 확인하세요.");
+        }
+    };
 
-  const handleFileUpload = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-    const fileTag = `<a href="#" style="color: #3498db;">📎 ${file.name}</a>`;
-    insertHTML(fileTag);
-  };
+    const handleFileUpload = (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const fileTag = `<a href="#" style="color: #3498db;">📎 ${file.name}</a>`;
+        insertHTML(fileTag);
+    };
 
   const handleSubmit = async () => {
     const content = editorRef.current.innerHTML.trim();
@@ -107,10 +107,10 @@ const WritePage = () => {
       return;
     }
 
-    const tempDiv = document.createElement("div");
-    tempDiv.innerHTML = content;
-    const firstImg = tempDiv.querySelector("img");
-    const imageUrls = firstImg ? firstImg.src : null;
+        const tempDiv = document.createElement("div");
+        tempDiv.innerHTML = content;
+        const firstImg = tempDiv.querySelector("img");
+        const imageUrls = firstImg ? firstImg.src : null;
 
     try {
       if (isEditMode) {
@@ -174,34 +174,34 @@ const WritePage = () => {
     selection.addRange(newRange);
   };
 
-  const increaseFontSize = () => changeFontSize(1);
-  const decreaseFontSize = () => changeFontSize(-1);
+    const increaseFontSize = () => changeFontSize(1);
+    const decreaseFontSize = () => changeFontSize(-1);
 
-  const applyLink = () => {
-    const selection = window.getSelection();
-    if (!selection.rangeCount || selection.isCollapsed) {
-      alert("먼저 링크로 만들 텍스트를 드래그하세요.");
-      return;
-    }
-    const url = prompt("링크 주소를 입력하세요 (https:// 포함)");
-    if (!url || !/^https?:\/\//.test(url)) {
-      alert("올바른 링크 형식을 입력해 주세요 (https://...)");
-      return;
-    }
-    const range = selection.getRangeAt(0);
-    const link = document.createElement("a");
-    link.href = url;
-    link.target = "_blank";
-    link.rel = "noopener noreferrer";
-    link.textContent = selection.toString();
-    range.deleteContents();
-    range.insertNode(link);
-    editorRef.current.focus();
-  };
+    const applyLink = () => {
+        const selection = window.getSelection();
+        if (!selection.rangeCount || selection.isCollapsed) {
+            alert("먼저 링크로 만들 텍스트를 드래그하세요.");
+            return;
+        }
+        const url = prompt("링크 주소를 입력하세요 (https:// 포함)");
+        if (!url || !/^https?:\/\//.test(url)) {
+            alert("올바른 링크 형식을 입력해 주세요 (https://...)");
+            return;
+        }
+        const range = selection.getRangeAt(0);
+        const link = document.createElement("a");
+        link.href = url;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.textContent = selection.toString();
+        range.deleteContents();
+        range.insertNode(link);
+        editorRef.current.focus();
+    };
 
   return (
     <div className="WritePage">
-      <Header title="Community" />
+      <Header />
       <div className="write-layout">
         <div className="write-main">
           <h2 className="write-title">

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -15,6 +15,15 @@ button {
     padding: 0;
 }
 
+dl,
+ol,
+ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: 100%;
+}
+
 img {
     max-width: 100%;
     height: auto;


### PR DESCRIPTION
## Summary

- 헤더 우측 영역 중심으로 UI/UX 개선 및 리팩터링을 진행했습니다.

## Tasks

**1. 공통**
- react-icons 라이브러리 추가
- 헤더 관련 버튼 및 아이콘 스타일 통합 (header-btn 클래스)
- 기본 스타일 초기화에 ::before, ::after, 리스트 스타일 초기화 추가

**2. GNB & 아이콘**
- GNB 툴팁 내 서브메뉴별 아이콘 추가
- Sidebar에서 불필요한 LogOut 아이콘 제거 및 코드 정리

**3. Header 컴포넌트 리팩터링**
- title prop 제거
- BoardPage, MailPage, MyPage, MyPageV2, WritePage 등에서 Header 사용 방식 수정

**4. 알림(BellBox) 개선**
- 알림 아이콘에 새 알림 시 애니메이션 효과 추가
- 관련 클래스명 notice -> notification으로 일괄 변경
- 드롭다운 상단 툴팁 디자인 추가 및 구조 개선 (notification-header, notification-list)
- 내부 스타일 개선 및 불필요한 클래스 제거

**5. 메일(MailBox) 개선**
- 개별 버튼 스타일 제거, 공통 스타일(header-btn)로 통합

**6. 프로필 기능 추가**
- 헤더 우측에 프로필 버튼 추가
- MyProfile 컴포넌트에서 프로필 이미지 동기화 로직 개선
- 프로필 드롭다운 메뉴(마이 페이지, 로그아웃) 추가
- 화면 크기에 따른 드롭다운 메뉴 위치 보정

## To Reviewer

- npm install 해주세요.
- 메일은 우측 사이드에서 열리도록 개선하면 좋을 것 같습니다.
- 읽지 않은 알림은 파란색 배경으로 강조되고 있는데, 읽은 알림은 즉시 삭제되므로 배경 강조 효과가 무의미합니다. 알림 읽음, 알림 삭제 기능이 구분되어야 할 듯 합니다.
- 프로필 드롭다운 메뉴는 일단 마이페이지만 링크했습니다. 마이페이지 내 서브메뉴들이 정돈되면 더 추가하겠습니다.

## Screenshot

- GNB & 아이콘
<img width="269" height="223" alt="스크린샷 2025-08-13 오후 7 34 05" src="https://github.com/user-attachments/assets/729b0cdd-7e52-4e4b-b080-65137dd1f80f" />
<img width="267" height="286" alt="스크린샷 2025-08-13 오후 7 34 11" src="https://github.com/user-attachments/assets/2b27554b-e9e4-4947-8d41-ec6c2cccbedd" />
<img width="266" height="105" alt="스크린샷 2025-08-13 오후 7 34 16" src="https://github.com/user-attachments/assets/6e05bb48-98c7-4d07-b409-84fc2a9bbc21" />

- 헤더 우측 영역
<img width="758" height="160" alt="image" src="https://github.com/user-attachments/assets/d235ac77-09bc-4d02-a6d3-3783a625b1a9" />

- 알림
<img width="576" height="650" alt="image" src="https://github.com/user-attachments/assets/c54bbd04-4c98-4c3b-a42b-a6f0aa551ad1" />

- 프로필
<img width="358" height="318" alt="image" src="https://github.com/user-attachments/assets/32f2b9f4-36e8-4b7b-bd8f-10ecf3d20881" />
