### PR TITLE
[feat] 비밀번호 찾기 기능 및 UI 개선

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
     "tabWidth": 4,
     "semi": true,
     "singleQuote": false,
-    "endOfLine": "auto"
+    "endOfLine": "auto",
+    "plugins": ["@trivago/prettier-plugin-sort-imports"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
+                "@trivago/prettier-plugin-sort-imports": "^5.2.2",
                 "@types/react": "^19.0.8",
                 "@types/react-dom": "^19.0.3",
                 "@vitejs/plugin-react": "^4.4.1",
@@ -1542,6 +1543,41 @@
             "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
             "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
             "license": "MIT"
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
+            "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/generator": "^7.26.5",
+                "@babel/parser": "^7.26.7",
+                "@babel/traverse": "^7.26.7",
+                "@babel/types": "^7.26.7",
+                "javascript-natural-sort": "^0.7.1",
+                "lodash": "^4.17.21"
+            },
+            "engines": {
+                "node": ">18.12"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "3.x",
+                "prettier": "2.x - 3.x",
+                "prettier-plugin-svelte": "3.x",
+                "svelte": "4.x || 5.x"
+            },
+            "peerDependenciesMeta": {
+                "@vue/compiler-sfc": {
+                    "optional": true
+                },
+                "prettier-plugin-svelte": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -4308,6 +4344,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/javascript-natural-sort": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5143,6 +5186,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/prop-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
                 "react-icons": "^5.5.0",
                 "react-router-dom": "^7.2.0",
                 "react-spinners": "^0.17.0",
-                "recharts": "^3.1.2"
+                "recharts": "^3.1.2",
+                "sonner": "^2.0.7"
             },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
@@ -5883,6 +5884,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/sonner": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+            "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+                "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
             }
         },
         "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
+        "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.2.0",
         "react-spinners": "^0.17.0",
-        "recharts": "^3.1.2"
+        "recharts": "^3.1.2",
+        "sonner": "^2.0.7"
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/src/App.css
+++ b/src/App.css
@@ -7,18 +7,25 @@ html {
     --point-text-color-blue: #0969da;
     --point-green: #1f883d;
     --point-focus-green: #1a7f37;
+    --focus-border-color: #41bbfc;
+    --active-button-color: #3189d3;
 
     --base-border-color: #d1d9e0; /* 회색 경계선 색 */
     --light-border-color: #e7e8ea;
 
     --base-point-color: #f6f8fa;
-    --board-shadow-color: 0px 1px 1px 0px #25292e1a, 0px 1px 6px 0px #25292e1f; /* 게시판 그림자 */
+    --board-shadow-color:
+        0px 1px 1px 0px #25292e1a, 0px 1px 6px 0px #25292e1f; /* 게시판 그림자 */
     --red-dot-color: #f56565;
 
     --background-color: #fafafa;
     --normal-text-color: #59636e;
 
     --hover-gray-color: #e2e8f0;
+
+    --transition-input-focus:
+        border-color 0.3s ease, background-color 0.3s ease;
+    --transition-bg-color: background-color 0.3s ease;
 
     /* 반응형 변수 */
     --medium-screen-gap: 15px;
@@ -38,9 +45,15 @@ html {
     --font-size-5xl: 3rem; /* 48px */
 
     /* 스페이싱 - 모바일 */
+    --spacing-1-5: 0.375rem; /* 6px */
     --spacing-2: 0.5rem; /* 8px */
+    --spacing-2-5: 0.625rem; /* 10px */
     --spacing-3: 0.75rem; /* 12px */
     --spacing-4: 1rem; /* 16px */
+    --spacing-6: 1.5rem; /* 24px */
+    --spacing-8: 2rem; /* 32px */
+    --spacing-10: 2.5rem; /* 40px */
+    --spacing-64: 16rem; /* 256px */
 }
 
 /* 태블릿 크기 */
@@ -58,9 +71,15 @@ html {
         --font-size-4xl: 2.5rem; /* 40px */
         --font-size-5xl: 3.5rem; /* 56px */
 
-        --spacing-2: 0.75rem; /* 12px */
+        --spacing-1-5: 0.5rem; /* 8px */
+        --spacing-2: 0.625rem; /* 10px */
+        --spacing-2-5: 0.75rem; /* 12px */
         --spacing-3: 1rem; /* 16px */
         --spacing-4: 1.25rem; /* 20px */
+        --spacing-6: 1.75rem; /* 28px */
+        --spacing-8: 2.25rem; /* 36px */
+        --spacing-10: 2.75rem; /* 44px */
+        --spacing-64: 18rem; /* 288px */
     }
 }
 
@@ -79,9 +98,15 @@ html {
         --font-size-4xl: 3.25rem; /* 52px */
         --font-size-5xl: 4rem; /* 64px */
 
-        --spacing-2: 1rem; /* 16px */
+        --spacing-1-5: 0.625rem; /* 10px */
+        --spacing-2: 0.75rem; /* 12px */
+        --spacing-2-5: 0.875rem; /* 14px */
         --spacing-3: 1.25rem; /* 20px */
         --spacing-4: 1.5rem; /* 24px */
+        --spacing-6: 2rem; /* 32px */
+        --spacing-8: 2.5rem; /* 40px */
+        --spacing-10: 3rem; /* 48px */
+        --spacing-64: 20rem; /* 320px */
     }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -23,6 +23,9 @@ html {
 
     --hover-gray-color: #e2e8f0;
 
+    --error-color: #ee5f5f;
+    --error-bg-color: #fff5f5;
+
     --transition-input-focus:
         border-color 0.3s ease, background-color 0.3s ease;
     --transition-bg-color: background-color 0.3s ease;
@@ -74,7 +77,7 @@ html {
         --spacing-1-5: 0.5rem; /* 8px */
         --spacing-2: 0.625rem; /* 10px */
         --spacing-2-5: 0.75rem; /* 12px */
-        --spacing-3: 1rem; /* 16px */
+        --spacing-3: 0.875rem; /* 14px */
         --spacing-4: 1.25rem; /* 20px */
         --spacing-6: 1.75rem; /* 28px */
         --spacing-8: 2.25rem; /* 36px */
@@ -101,7 +104,7 @@ html {
         --spacing-1-5: 0.625rem; /* 10px */
         --spacing-2: 0.75rem; /* 12px */
         --spacing-2-5: 0.875rem; /* 14px */
-        --spacing-3: 1.25rem; /* 20px */
+        --spacing-3: 1rem; /* 16px */
         --spacing-4: 1.5rem; /* 24px */
         --spacing-6: 2rem; /* 32px */
         --spacing-8: 2.5rem; /* 40px */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import LecturePostDetail from "./components/post/LecturePostDetail.jsx";
 import TestPage from "./pages/TestPage.jsx";
 import MyActivity from "./components/mypage/MyActivity.jsx";
 import Account from "./components/mypage/Account.jsx";
+import { Toaster } from "sonner";
 
 function App() {
     const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -64,6 +65,7 @@ function App() {
     return (
         <UserProvider>
             <div className="body-container">
+                <Toaster richColors />
                 <Routes>
                     <Route
                         path="/"

--- a/src/components/LoginForm.css
+++ b/src/components/LoginForm.css
@@ -33,7 +33,7 @@
     border-radius: 6px;
     font-size: 20px;
     color: #333;
-    background-color: #f9f9f9;
+    background-color: var(--background-color);
     transition: border-color 0.3s ease, background-color 0.3s ease;
 }
 

--- a/src/components/RegisterForm.css
+++ b/src/components/RegisterForm.css
@@ -33,7 +33,7 @@
     border-radius: 6px;
     font-size: 20px;
     color: #333;
-    background-color: #f9f9f9;
+    background-color: var(--background-color);
     transition: border-color 0.3s ease, background-color 0.3s ease;
 }
 

--- a/src/components/RegisterForm.jsx
+++ b/src/components/RegisterForm.jsx
@@ -204,7 +204,7 @@ const RegisterForm = () => {
                     />
                     {codeError && <p className="error-message">{codeError}</p>}
 
-                    <Timer duration={180} triggerReset={timerKey} />
+                    <Timer duration={300} triggerReset={timerKey} />
 
                     <div className="button-group">
                         <button onClick={handleVerify} disabled={loading}>

--- a/src/components/RegisterForm.jsx
+++ b/src/components/RegisterForm.jsx
@@ -1,215 +1,234 @@
+import "./RegisterForm.css";
+import Timer from "./Timer";
+import axiosInstance from "./utils/AxiosInstance";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import ClipLoader from "react-spinners/ClipLoader";
-import axiosInstance from "./utils/AxiosInstance";
-import Timer from "./Timer";
-import "./RegisterForm.css";
 
 const RegisterForm = () => {
-  const [formData, setFormData] = useState({
-    username: "",
-    password: "",
-    email: "",
-    name: "",
-  });
+    const [formData, setFormData] = useState({
+        username: "",
+        password: "",
+        email: "",
+        name: "",
+    });
 
-  const [step, setStep] = useState("form"); // form, loading, verify
-  const [verificationCode, setVerificationCode] = useState("");
-  const [emailError, setEmailError] = useState("");
-  const [codeError, setCodeError] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [resendLoading, setResendLoading] = useState(false);
+    const [step, setStep] = useState("form"); // form, loading, verify
+    const [verificationCode, setVerificationCode] = useState("");
+    const [emailError, setEmailError] = useState("");
+    const [codeError, setCodeError] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [resendLoading, setResendLoading] = useState(false);
 
-  const [timerKey, setTimerKey] = useState(0);
+    const [timerKey, setTimerKey] = useState(0);
 
-  const navigate = useNavigate();
+    const navigate = useNavigate();
 
-  const handleChange = (e) => {
-    setFormData((prev) => ({
-      ...prev,
-      [e.target.name]: e.target.value,
-    }));
+    const handleChange = (e) => {
+        setFormData((prev) => ({
+            ...prev,
+            [e.target.name]: e.target.value,
+        }));
 
-    if (e.target.name === "email") setEmailError("");
-    if (e.target.name === "verificationCode") setCodeError("");
-  };
+        if (e.target.name === "email") setEmailError("");
+        if (e.target.name === "verificationCode") setCodeError("");
+    };
 
-  // 타이머 시작은 timerKey 증가로 처리
-  const startTimer = () => {
-    setTimerKey((prev) => prev + 1);
-  };
+    // 타이머 시작은 timerKey 증가로 처리
+    const startTimer = () => {
+        setTimerKey((prev) => prev + 1);
+    };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setEmailError("");
-    setLoading(true);
-    setStep("loading");
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setEmailError("");
+        setLoading(true);
+        setStep("loading");
 
-    try {
-      await axiosInstance.post("/auth/email-check", { email: formData.email });
-      setStep("verify");
-      startTimer();
-    } catch (error) {
-      console.error("인증 메일 발송 실패:", error);
-      if (error.response?.status === 400) {
-        setEmailError(error.response.data.message || "이미 가입된 이메일입니다.");
-        setStep("form");
-      } else {
-        alert(error.response?.data?.message || "인증 메일 발송 실패");
-        setStep("form");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
+        try {
+            await axiosInstance.post("/auth/email-check", {
+                email: formData.email,
+            });
+            setStep("verify");
+            startTimer();
+        } catch (error) {
+            console.error("인증 메일 발송 실패:", error);
+            if (error.response?.status === 400) {
+                setEmailError(
+                    error.response.data.message || "이미 가입된 이메일입니다.",
+                );
+                setStep("form");
+            } else {
+                alert(error.response?.data?.message || "인증 메일 발송 실패");
+                setStep("form");
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  const handleVerify = async () => {
-    setCodeError("");
-    try {
-      await axiosInstance.post("/auth/verify-code", {
-        email: formData.email,
-        code: verificationCode,
-      });
-      const response = await axiosInstance.post("/member/join", formData);
-      alert("회원가입 성공!");
-      navigate("/login");
-    } catch (error) {
-      console.error("인증 실패:", error);
-      if (error.response?.status === 400 || error.response?.status === 403) {
-        setCodeError(error.response.data.message || "인증번호가 올바르지 않습니다.");
-      } else {
-        alert(error.response?.data?.message || "인증 실패");
-      }
-    }
-  };
+    const handleVerify = async () => {
+        setCodeError("");
+        try {
+            await axiosInstance.post("/auth/verify-code", {
+                email: formData.email,
+                code: verificationCode,
+            });
+            const response = await axiosInstance.post("/member/join", formData);
+            alert("회원가입 성공!");
+            navigate("/login");
+        } catch (error) {
+            console.error("인증 실패:", error);
+            if (
+                error.response?.status === 400 ||
+                error.response?.status === 403
+            ) {
+                setCodeError(
+                    error.response.data.message ||
+                        "인증번호가 올바르지 않습니다.",
+                );
+            } else {
+                alert(error.response?.data?.message || "인증 실패");
+            }
+        }
+    };
 
-  const handleResend = async () => {
-    setResendLoading(true);
-    setEmailError("");
-    setCodeError("");
-    try {
-      await axiosInstance.post("/auth/email-check", { email: formData.email });
-      alert("인증 코드가 다시 발송되었습니다.");
-      startTimer();
-    } catch (error) {
-      console.error("재전송 실패:", error);
-      alert(error.response?.data?.message || "인증 코드 재전송 실패");
-    } finally {
-      setResendLoading(false);
-    }
-  };
+    const handleResend = async () => {
+        setResendLoading(true);
+        setEmailError("");
+        setCodeError("");
+        try {
+            await axiosInstance.post("/auth/email-check", {
+                email: formData.email,
+            });
+            alert("인증 코드가 다시 발송되었습니다.");
+            startTimer();
+        } catch (error) {
+            console.error("재전송 실패:", error);
+            alert(error.response?.data?.message || "인증 코드 재전송 실패");
+        } finally {
+            setResendLoading(false);
+        }
+    };
 
-  return (
-    <div className="RegisterForm">
-      {step === "form" && (
-        <form className="form" onSubmit={handleSubmit}>
-          <div className="form-group">
-            <label>ID:</label>
-            <input
-              type="string"
-              name="username"
-              value={formData.username}
-              onChange={handleChange}
-              required
-              placeholder="학번"
-              disabled={loading}
-            />
-          </div>
+    return (
+        <div className="RegisterForm">
+            {step === "form" && (
+                <form className="form" onSubmit={handleSubmit}>
+                    <div className="form-group">
+                        <label>ID:</label>
+                        <input
+                            type="string"
+                            name="username"
+                            value={formData.username}
+                            onChange={handleChange}
+                            required
+                            placeholder="학번"
+                            disabled={loading}
+                        />
+                    </div>
 
-          <div className="form-group">
-            <label>Password:</label>
-            <input
-              type="password"
-              name="password"
-              value={formData.password}
-              onChange={handleChange}
-              required
-              placeholder="비밀번호"
-              disabled={loading}
-            />
-          </div>
+                    <div className="form-group">
+                        <label>Password:</label>
+                        <input
+                            type="password"
+                            name="password"
+                            value={formData.password}
+                            onChange={handleChange}
+                            required
+                            placeholder="비밀번호"
+                            disabled={loading}
+                        />
+                    </div>
 
-          <div className="form-group">
-            <label>Email:</label>
-            <input
-              type="email"
-              name="email"
-              value={formData.email}
-              onChange={handleChange}
-              required
-              placeholder="이메일"
-              disabled={loading}
-            />
-            {emailError && <p className="error-message">{emailError}</p>}
-          </div>
+                    <div className="form-group">
+                        <label>Email:</label>
+                        <input
+                            type="email"
+                            name="email"
+                            value={formData.email}
+                            onChange={handleChange}
+                            required
+                            placeholder="이메일"
+                            disabled={loading}
+                        />
+                        {emailError && (
+                            <p className="error-message">{emailError}</p>
+                        )}
+                    </div>
 
-          <div className="form-group">
-            <label>Name:</label>
-            <input
-              type="text"
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              required
-              placeholder="이름"
-              disabled={loading}
-            />
-          </div>
+                    <div className="form-group">
+                        <label>Name:</label>
+                        <input
+                            type="text"
+                            name="name"
+                            value={formData.name}
+                            onChange={handleChange}
+                            required
+                            placeholder="이름"
+                            disabled={loading}
+                        />
+                    </div>
 
-          <button type="submit" disabled={loading}>
-            {loading ? "로딩중..." : "제출"}
-          </button>
-        </form>
-      )}
+                    <button type="submit" disabled={loading}>
+                        {loading ? "로딩중..." : "제출"}
+                    </button>
+                </form>
+            )}
 
-      {step === "loading" && (
-        <div className="loading-container" style={{ textAlign: "center", marginTop: 40 }}>
-          <ClipLoader color="#36d7b7" size={50} />
-          <p>인증 메일을 보내는 중입니다...</p>
+            {step === "loading" && (
+                <div
+                    className="loading-container"
+                    style={{ textAlign: "center", marginTop: 40 }}
+                >
+                    <ClipLoader color="#36d7b7" size={50} />
+                    <p>인증 메일을 보내는 중입니다...</p>
+                </div>
+            )}
+
+            {step === "verify" && (
+                <div className="verify-container">
+                    <p>
+                        {formData.email} 주소로 인증 코드를 보냈습니다.
+                        <br />
+                        아래에 인증 코드를 입력해주세요.
+                    </p>
+                    <input
+                        type="text"
+                        value={verificationCode}
+                        onChange={(e) => {
+                            setVerificationCode(e.target.value);
+                            setCodeError("");
+                        }}
+                        placeholder="인증 코드 입력"
+                    />
+                    {codeError && <p className="error-message">{codeError}</p>}
+
+                    <Timer duration={180} triggerReset={timerKey} />
+
+                    <div className="button-group">
+                        <button onClick={handleVerify} disabled={loading}>
+                            확인
+                        </button>
+
+                        <button
+                            onClick={handleResend}
+                            disabled={resendLoading}
+                            style={{ marginLeft: "10px" }}
+                        >
+                            {resendLoading
+                                ? "재전송 중..."
+                                : "인증 코드 재전송"}
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <Link className="link-button" to={"/login"}>
+                로그인 화면으로
+            </Link>
         </div>
-      )}
-
-      {step === "verify" && (
-        <div className="verify-container">
-          <p>
-            {formData.email} 주소로 인증 코드를 보냈습니다.
-            <br />
-            아래에 인증 코드를 입력해주세요.
-          </p>
-          <input
-            type="text"
-            value={verificationCode}
-            onChange={(e) => {
-              setVerificationCode(e.target.value);
-              setCodeError("");
-            }}
-            placeholder="인증 코드 입력"
-          />
-          {codeError && <p className="error-message">{codeError}</p>}
-
-          <Timer duration={180} triggerReset={timerKey} />
-
-          <div className="button-group">
-            <button onClick={handleVerify} disabled={loading}>
-              확인
-            </button>
-
-            <button
-              onClick={handleResend}
-              disabled={resendLoading}
-              style={{ marginLeft: "10px" }}
-            >
-              {resendLoading ? "재전송 중..." : "인증 코드 재전송"}
-            </button>
-          </div>
-        </div>
-      )}
-
-      <Link className="link-button" to={"/login"}>
-        로그인 화면으로
-      </Link>
-    </div>
-  );
+    );
 };
 
 export default RegisterForm;

--- a/src/components/ResetPasswordForm.css
+++ b/src/components/ResetPasswordForm.css
@@ -17,7 +17,7 @@
 .reset-pw-box .caption {
     margin-bottom: var(--spacing-6);
     color: #7b90a6;
-    font-size: var(--spacing-2-5);
+    font-size: var(--font-size-2xs);
 }
 
 .reset-pw-box .input-field {
@@ -73,11 +73,25 @@
 
 .reset-pw-box .error-message {
     margin-top: 2px;
-    padding-left: var(--spacing-2-5);
+    padding-left: var(--spacing-1-5);
     color: var(--error-color);
     font-size: var(--font-size-3xs);
 }
 
-.reset-message {
-    color: #4a90e2; /* 성공 메시지는 파랑 */
+.reset-pw-box .timer-resend-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 3px;
+}
+
+.reset-pw-box .resend-btn {
+    color: #4a90e2;
+    font-size: var(--font-size-3xs);
+    text-decoration: underline;
+    transition: color 0.2s ease;
+}
+
+.reset-pw-box .resend-btn:hover {
+    color: #357abd;
 }

--- a/src/components/ResetPasswordForm.css
+++ b/src/components/ResetPasswordForm.css
@@ -1,71 +1,79 @@
-.reset-password-form {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  width: 100%;
-  max-width: 350px;
-  margin: 0 auto;
-  padding: 20px;
-  box-sizing: border-box;
+.reset-pw-box {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: var(--spacing-64);
+    margin: 0 auto;
+    line-height: 1.5;
 }
 
-.reset-password-form h2 {
-  font-size: 22px;
-  font-weight: bold;
-  margin-bottom: 4px;
-  text-align: center;
-  color: #333;
+.reset-pw-box .title {
+    margin-bottom: var(--spacing-1-5);
+    color: #001e40;
+    font-size: var(--font-size-sm);
+    font-weight: 700;
 }
 
-.reset-password-form p {
-  font-size: 14px;
-  text-align: center;
-  color: #666;
-  margin-bottom: 16px;
+.reset-pw-box .caption {
+    margin-bottom: var(--spacing-6);
+    color: #7b90a6;
+    font-size: var(--spacing-2-5);
 }
 
-.reset-password-form input {
-  padding: 10px 12px;
-  border: 1px solid #ddd;
-  border-radius: 6px;
-  font-size: 14px;
-  outline: none;
-  transition: border-color 0.2s;
+.reset-pw-box .input-field {
+    display: flex;
+    flex-direction: column;
 }
 
-.reset-password-form input:focus {
-  border-color: #4a90e2; /* 포커스 시 파란색 */
+.reset-pw-box .input-field label {
+    margin-bottom: 2px;
+    color: #7b90a6;
+    font-size: var(--font-size-3xs);
+    font-weight: 600;
 }
 
-.reset-password-form button {
-  padding: 10px 12px;
-  background-color: #4a90e2;
-  color: white;
-  font-size: 15px;
-  font-weight: 600;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background-color 0.2s, opacity 0.2s;
+.reset-pw-box .input-field input {
+    border: 1px solid #ddd;
+    width: 100%;
+    height: var(--spacing-8);
+    padding: var(--spacing-2);
+    background: var(--background-color);
+    border-radius: 0.375rem;
+    font-size: var(--font-size-2xs);
+    line-height: 2.375;
+    transition: var(--transition-input-focus);
 }
 
-.reset-password-form button:hover:not(:disabled) {
-  background-color: #357abd;
+.reset-pw-box .input-field input:focus {
+    border-color: var(--focus-border-color);
+    background-color: #fff;
+    outline: none;
 }
 
-.reset-password-form button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.reset-pw-box button[type="submit"] {
+    width: 100%;
+    height: var(--spacing-10);
+    margin-top: var(--spacing-6);
+    font-size: var(--font-size-xs);
+    border-radius: 0.375rem;
+    padding: var(--spacing-2);
+    color: white;
+    background-color: var(--active-button-color);
+    transition: var(--transition-bg-color);
+}
+
+.reset-pw-box button[type="submit"]:disabled {
+    background-color: var(--base-blue-color);
 }
 
 .reset-message {
-  margin-top: 8px;
-  font-size: 14px;
-  text-align: center;
-  color: #4a90e2; /* 성공 메시지는 파랑 */
+    margin-top: 8px;
+    font-size: 14px;
+    text-align: center;
+    color: #4a90e2; /* 성공 메시지는 파랑 */
 }
 
 /* 에러일 때 메시지 색상 다르게 */
 .reset-message.error {
-  color: #e74c3c;
+    color: #e74c3c;
 }

--- a/src/components/ResetPasswordForm.css
+++ b/src/components/ResetPasswordForm.css
@@ -50,6 +50,11 @@
     outline: none;
 }
 
+.reset-pw-box .input-field .input-error {
+    border-color: var(--error-color);
+    background-color: var(--error-bg-color);
+}
+
 .reset-pw-box button[type="submit"] {
     width: 100%;
     height: var(--spacing-10);
@@ -66,14 +71,13 @@
     background-color: var(--base-blue-color);
 }
 
-.reset-message {
-    margin-top: 8px;
-    font-size: 14px;
-    text-align: center;
-    color: #4a90e2; /* 성공 메시지는 파랑 */
+.reset-pw-box .error-message {
+    margin-top: 2px;
+    padding-left: var(--spacing-2-5);
+    color: var(--error-color);
+    font-size: var(--font-size-3xs);
 }
 
-/* 에러일 때 메시지 색상 다르게 */
-.reset-message.error {
-    color: #e74c3c;
+.reset-message {
+    color: #4a90e2; /* 성공 메시지는 파랑 */
 }

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -127,33 +127,36 @@ const ResetPasswordForm = () => {
     };
 
     return (
-        <div className="reset-password-form">
+        <div className="reset-pw-box">
             {/* Step 1: 아이디 입력 */}
             {step === 1 && (
                 <form onSubmit={handleSubmitUsername}>
-                    <h2>비밀번호 찾기</h2>
-                    <p>가입하신 아이디를 입력해주세요.</p>
+                    <h2 className="title">비밀번호를 잊으셨나요?</h2>
+                    <p className="caption">
+                        학번/교번을 입력하시면,
+                        <br />
+                        인증코드를 보내드려요.
+                    </p>
 
-                    <input
-                        type="text"
-                        placeholder="아이디"
-                        value={username}
-                        onChange={(e) => setUsername(e.target.value)}
-                        required
-                    />
+                    <div className="input-field">
+                        <label htmlFor="username">학번/교번</label>
+                        <input
+                            className="input-focus"
+                            type="text"
+                            id="username"
+                            value={username}
+                            placeholder="ex ) 20251234"
+                            maxLength="255"
+                            onChange={(e) => setUsername(e.target.value)}
+                            required
+                        />
+                    </div>
 
-                    <button type="submit" disabled={loading}>
-                        {loading ? "확인 중..." : "다음"}
+                    <button type="submit" disabled={loading  || !username}>
+                        {loading ? "확인 중..." : "인증코드 보내기"}
                     </button>
 
                     {message && <p className="reset-message">{message}</p>}
-                    <button
-                        type="button"
-                        className="login-button"
-                        onClick={handleGoLogin}
-                    >
-                        로그인 화면으로 이동
-                    </button>
                 </form>
             )}
 

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -1,4 +1,5 @@
 import "./ResetPasswordForm.css";
+import Timer from "./Timer";
 import axiosInstance from "./utils/AxiosInstance";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -13,8 +14,13 @@ const ResetPasswordForm = () => {
     const [newPassword, setNewPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
     const [error, setError] = useState(false); // 에러 여부
+    const [timerKey, setTimerKey] = useState(0);
 
     const navigate = useNavigate();
+
+    const startTimer = () => {
+        setTimerKey((prev) => prev + 1);
+    };
 
     // Step 1: 아이디 제출
     const handleSubmitUsername = async (e) => {
@@ -157,7 +163,9 @@ const ResetPasswordForm = () => {
                             }}
                             required
                         />
-                        {error && message && <p className="error-message">{message}</p>}
+                        {error && message && (
+                            <p className="error-message">{message}</p>
+                        )}
                     </div>
 
                     <button type="submit" disabled={loading || !username}>
@@ -179,6 +187,7 @@ const ResetPasswordForm = () => {
                         onChange={(e) => setCode(e.target.value)}
                         required
                     />
+                    <Timer duration={180} triggerReset={timerKey} />
 
                     <button type="submit">확인</button>
 

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -12,6 +12,7 @@ const ResetPasswordForm = () => {
     const [code, setCode] = useState(""); // 사용자 입력 코드
     const [newPassword, setNewPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
+    const [error, setError] = useState(false); // 에러 여부
 
     const navigate = useNavigate();
 
@@ -19,7 +20,7 @@ const ResetPasswordForm = () => {
     const handleSubmitUsername = async (e) => {
         e.preventDefault();
         if (!username) {
-            setMessage("아이디를 입력해주세요.");
+            setMessage("학번/교번을 입력해주세요.");
             return;
         }
         setLoading(true);
@@ -34,8 +35,10 @@ const ResetPasswordForm = () => {
                 setStep(2); // 인증코드 입력 단계로 이동
             } else {
                 setMessage(
-                    response.data?.message || "등록된 아이디가 없습니다.",
+                    response.data?.message ||
+                        "일치하는 회원정보가 없습니다. 다시 입력해주세요.",
                 );
+                setError(true);
             }
         } catch (error) {
             setMessage(
@@ -43,6 +46,7 @@ const ResetPasswordForm = () => {
                     "아이디 확인 중 오류가 발생했습니다.",
             );
             console.error(error);
+            setError(true);
         } finally {
             setLoading(false);
         }
@@ -141,22 +145,24 @@ const ResetPasswordForm = () => {
                     <div className="input-field">
                         <label htmlFor="username">학번/교번</label>
                         <input
-                            className="input-focus"
+                            className={`input-focus ${error ? "input-error" : ""}`}
                             type="text"
                             id="username"
                             value={username}
                             placeholder="ex ) 20251234"
                             maxLength="255"
-                            onChange={(e) => setUsername(e.target.value)}
+                            onChange={(e) => {
+                                setUsername(e.target.value);
+                                if (error) setError(false);
+                            }}
                             required
                         />
+                        {error && message && <p className="error-message">{message}</p>}
                     </div>
 
-                    <button type="submit" disabled={loading  || !username}>
+                    <button type="submit" disabled={loading || !username}>
                         {loading ? "확인 중..." : "인증코드 보내기"}
                     </button>
-
-                    {message && <p className="reset-message">{message}</p>}
                 </form>
             )}
 

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -38,7 +38,6 @@ const ResetPasswordForm = () => {
             });
             if (response.data?.success) {
                 setEmail(response.data.email); // 서버에서 받은 email 저장
-                // alert(`${response.data.email}로 인증코드를 발송했습니다.`);
                 toast.success(
                     `${response.data.email}로 인증코드를 발송했습니다.`,
                 );
@@ -88,7 +87,7 @@ const ResetPasswordForm = () => {
                 error.response?.data?.message ||
                     "인증코드 확인 중 오류가 발생했습니다.",
             );
-            console.error(error);
+            setError(true);
         } finally {
             setLoading(false);
         }
@@ -160,7 +159,7 @@ const ResetPasswordForm = () => {
                             id="username"
                             value={username}
                             placeholder="ex ) 20251234"
-                            maxLength="255"
+                            maxLength={255}
                             onChange={(e) => {
                                 setUsername(e.target.value);
                                 if (error) setError(false);
@@ -181,27 +180,42 @@ const ResetPasswordForm = () => {
             {/* Step 2: 인증코드 확인 */}
             {step === 2 && (
                 <form onSubmit={handleSubmitCode}>
-                    <h2>인증코드 확인</h2>
-                    <p>발송된 인증코드를 입력해주세요.</p>
+                    <h2 className="title">인증코드 확인</h2>
+                    <p className="caption">발송된 인증코드를 입력해주세요.</p>
 
-                    <input
-                        type="text"
-                        placeholder="인증코드"
-                        value={code}
-                        onChange={(e) => setCode(e.target.value)}
-                        required
-                    />
-                    <Timer duration={180} triggerReset={timerKey} />
+                    <div className="input-field">
+                        <label htmlFor="code">인증코드</label>
+                        <input
+                            className={`input-focus ${error ? "input-error" : ""}`}
+                            type="text"
+                            id="code"
+                            value={code}
+                            placeholder="인증코드 입력"
+                            maxLength={6}
+                            onChange={(e) => {
+                                setCode(e.target.value);
+                                if (error) setError(false);
+                            }}
+                            required
+                        />
+                        {error && message && (
+                            <p className="error-message">{message}</p>
+                        )}
+                        <div className="timer-resend-container">
+                            <Timer duration={300} triggerReset={timerKey} />
+                            <button
+                                type="button"
+                                className="resend-btn"
+                                onClick={handleSubmitUsername}
+                                disabled={loading}
+                            >
+                                {loading ? "요청 중..." : "인증코드 재전송"}
+                            </button>
+                        </div>
+                    </div>
 
-                    <button type="submit">확인</button>
-
-                    {message && <p className="reset-message">{message}</p>}
-                    <button
-                        type="button"
-                        className="login-button"
-                        onClick={handleGoLogin}
-                    >
-                        로그인 화면으로 이동
+                    <button type="submit" disabled={!code}>
+                        확인
                     </button>
                 </form>
             )}

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -1,203 +1,240 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import "./ResetPasswordForm.css";
 import axiosInstance from "./utils/AxiosInstance";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 const ResetPasswordForm = () => {
-  const [username, setUsername] = useState("");
-  const [step, setStep] = useState(1); // 1=아이디, 2=코드, 3=비밀번호 재설정, 4=완료
-  const [message, setMessage] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [email, setEmail] = useState("");
-  const [code, setCode] = useState(""); // 사용자 입력 코드
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+    const [username, setUsername] = useState("");
+    const [step, setStep] = useState(1); // 1=아이디, 2=코드, 3=비밀번호 재설정, 4=완료
+    const [message, setMessage] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [email, setEmail] = useState("");
+    const [code, setCode] = useState(""); // 사용자 입력 코드
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
 
-  const navigate = useNavigate();
+    const navigate = useNavigate();
 
-  // Step 1: 아이디 제출
-  const handleSubmitUsername = async (e) => {
-    e.preventDefault();
-    if (!username) {
-      setMessage("아이디를 입력해주세요.");
-      return;
-    }
-    setLoading(true);
-    setMessage("");
-    try {
-      const response = await axiosInstance.post("/member/verify-id", { username });
-      if (response.data?.success) {
-        setEmail(response.data.email); // 서버에서 받은 email 저장
-        setMessage("가입된 회원으로 인증코드를 보냈습니다.");
-        setStep(2); // 인증코드 입력 단계로 이동
-      } else {
-        setMessage(response.data?.message || "등록된 아이디가 없습니다.");
-      }
-    } catch (error) {
-      setMessage(error.response?.data?.message || "아이디 확인 중 오류가 발생했습니다.");
-      console.error(error);
-    } finally {
-      setLoading(false);
-    }
-  };
+    // Step 1: 아이디 제출
+    const handleSubmitUsername = async (e) => {
+        e.preventDefault();
+        if (!username) {
+            setMessage("아이디를 입력해주세요.");
+            return;
+        }
+        setLoading(true);
+        setMessage("");
+        try {
+            const response = await axiosInstance.post("/member/verify-id", {
+                username,
+            });
+            if (response.data?.success) {
+                setEmail(response.data.email); // 서버에서 받은 email 저장
+                setMessage("가입된 회원으로 인증코드를 보냈습니다.");
+                setStep(2); // 인증코드 입력 단계로 이동
+            } else {
+                setMessage(
+                    response.data?.message || "등록된 아이디가 없습니다.",
+                );
+            }
+        } catch (error) {
+            setMessage(
+                error.response?.data?.message ||
+                    "아이디 확인 중 오류가 발생했습니다.",
+            );
+            console.error(error);
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  // Step 2: 인증코드 제출
-  const handleSubmitCode = async (e) => {
-    e.preventDefault();
-    if (!code) {
-      setMessage("인증코드를 입력해주세요.");
-      return;
-    }
+    // Step 2: 인증코드 제출
+    const handleSubmitCode = async (e) => {
+        e.preventDefault();
+        if (!code) {
+            setMessage("인증코드를 입력해주세요.");
+            return;
+        }
 
-    setLoading(true);
-    setMessage("");
+        setLoading(true);
+        setMessage("");
 
-    try {
-      await axiosInstance.post("/auth/verify-code", {
-        email, // username 대신 email 사용
-        code,
-      });
+        try {
+            await axiosInstance.post("/auth/verify-code", {
+                email, // username 대신 email 사용
+                code,
+            });
 
-      setMessage("✅ 인증에 성공했습니다. 새로운 비밀번호를 설정해주세요.");
-      setStep(3); // 다음 단계로 이동
-    } catch (error) {
-      setMessage(error.response?.data?.message || "인증코드 확인 중 오류가 발생했습니다.");
-      console.error(error);
-    } finally {
-      setLoading(false);
-    }
-  };
+            setMessage(
+                "✅ 인증에 성공했습니다. 새로운 비밀번호를 설정해주세요.",
+            );
+            setStep(3); // 다음 단계로 이동
+        } catch (error) {
+            setMessage(
+                error.response?.data?.message ||
+                    "인증코드 확인 중 오류가 발생했습니다.",
+            );
+            console.error(error);
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  // Step 3: 새 비밀번호 제출
-  const handleSubmitNewPassword = async (e) => {
-    e.preventDefault();
+    // Step 3: 새 비밀번호 제출
+    const handleSubmitNewPassword = async (e) => {
+        e.preventDefault();
 
-    if (!newPassword || !confirmPassword) {
-      setMessage("비밀번호를 모두 입력해주세요.");
-      return;
-    }
-    if (newPassword !== confirmPassword) {
-      setMessage("비밀번호가 일치하지 않습니다.");
-      return;
-    }
+        if (!newPassword || !confirmPassword) {
+            setMessage("비밀번호를 모두 입력해주세요.");
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            setMessage("비밀번호가 일치하지 않습니다.");
+            return;
+        }
 
-    setLoading(true);
-    setMessage("");
+        setLoading(true);
+        setMessage("");
 
-    try {
-      const response = await axiosInstance.post("/member/reset-password/no-login", {
-        username,
-        newPassword,
-      });
+        try {
+            const response = await axiosInstance.post(
+                "/member/reset-password/no-login",
+                {
+                    username,
+                    newPassword,
+                },
+            );
 
-      setMessage(response.data?.message || "비밀번호가 성공적으로 재설정되었습니다.");
-      setStep(4); // 완료 단계로 이동
-    } catch (error) {
-      setMessage(error.response?.data?.message || "비밀번호 재설정 중 오류가 발생했습니다.");
-      console.error(error);
-    } finally {
-      setLoading(false);
-    }
-  };
+            setMessage(
+                response.data?.message ||
+                    "비밀번호가 성공적으로 재설정되었습니다.",
+            );
+            setStep(4); // 완료 단계로 이동
+        } catch (error) {
+            setMessage(
+                error.response?.data?.message ||
+                    "비밀번호 재설정 중 오류가 발생했습니다.",
+            );
+            console.error(error);
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  // 로그인 화면 이동
-  const handleGoLogin = () => {
-    navigate("/login");
-  };
+    // 로그인 화면 이동
+    const handleGoLogin = () => {
+        navigate("/login");
+    };
 
-  return (
-    <div className="reset-password-form">
-      {/* Step 1: 아이디 입력 */}
-      {step === 1 && (
-        <form onSubmit={handleSubmitUsername}>
-          <h2>비밀번호 찾기</h2>
-          <p>가입하신 아이디를 입력해주세요.</p>
+    return (
+        <div className="reset-password-form">
+            {/* Step 1: 아이디 입력 */}
+            {step === 1 && (
+                <form onSubmit={handleSubmitUsername}>
+                    <h2>비밀번호 찾기</h2>
+                    <p>가입하신 아이디를 입력해주세요.</p>
 
-          <input
-            type="text"
-            placeholder="아이디"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
-          />
+                    <input
+                        type="text"
+                        placeholder="아이디"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        required
+                    />
 
-          <button type="submit" disabled={loading}>
-            {loading ? "확인 중..." : "다음"}
-          </button>
+                    <button type="submit" disabled={loading}>
+                        {loading ? "확인 중..." : "다음"}
+                    </button>
 
-          {message && <p className="reset-message">{message}</p>}
-          <button type="button" className="login-button" onClick={handleGoLogin}>
-            로그인 화면으로 이동
-          </button>
-        </form>
-      )}
+                    {message && <p className="reset-message">{message}</p>}
+                    <button
+                        type="button"
+                        className="login-button"
+                        onClick={handleGoLogin}
+                    >
+                        로그인 화면으로 이동
+                    </button>
+                </form>
+            )}
 
-      {/* Step 2: 인증코드 확인 */}
-      {step === 2 && (
-        <form onSubmit={handleSubmitCode}>
-          <h2>인증코드 확인</h2>
-          <p>발송된 인증코드를 입력해주세요.</p>
+            {/* Step 2: 인증코드 확인 */}
+            {step === 2 && (
+                <form onSubmit={handleSubmitCode}>
+                    <h2>인증코드 확인</h2>
+                    <p>발송된 인증코드를 입력해주세요.</p>
 
-          <input
-            type="text"
-            placeholder="인증코드"
-            value={code}
-            onChange={(e) => setCode(e.target.value)}
-            required
-          />
+                    <input
+                        type="text"
+                        placeholder="인증코드"
+                        value={code}
+                        onChange={(e) => setCode(e.target.value)}
+                        required
+                    />
 
-          <button type="submit">확인</button>
+                    <button type="submit">확인</button>
 
-          {message && <p className="reset-message">{message}</p>}
-          <button type="button" className="login-button" onClick={handleGoLogin}>
-            로그인 화면으로 이동
-          </button>
-        </form>
-      )}
+                    {message && <p className="reset-message">{message}</p>}
+                    <button
+                        type="button"
+                        className="login-button"
+                        onClick={handleGoLogin}
+                    >
+                        로그인 화면으로 이동
+                    </button>
+                </form>
+            )}
 
-      {/* Step 3: 새 비밀번호 설정 */}
-      {step === 3 && (
-        <form onSubmit={handleSubmitNewPassword}>
-          <h2>새 비밀번호 설정</h2>
-          <p>새로운 비밀번호를 입력해주세요.</p>
+            {/* Step 3: 새 비밀번호 설정 */}
+            {step === 3 && (
+                <form onSubmit={handleSubmitNewPassword}>
+                    <h2>새 비밀번호 설정</h2>
+                    <p>새로운 비밀번호를 입력해주세요.</p>
 
-          <input
-            type="password"
-            placeholder="새 비밀번호"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            required
-          />
+                    <input
+                        type="password"
+                        placeholder="새 비밀번호"
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
+                        required
+                    />
 
-          <input
-            type="password"
-            placeholder="비밀번호 확인"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            required
-          />
+                    <input
+                        type="password"
+                        placeholder="비밀번호 확인"
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        required
+                    />
 
-          <button type="submit">비밀번호 변경</button>
+                    <button type="submit">비밀번호 변경</button>
 
-          {message && <p className="reset-message">{message}</p>}
-          <button type="button" className="login-button" onClick={handleGoLogin}>
-            로그인 화면으로 이동
-          </button>
-        </form>
-      )}
+                    {message && <p className="reset-message">{message}</p>}
+                    <button
+                        type="button"
+                        className="login-button"
+                        onClick={handleGoLogin}
+                    >
+                        로그인 화면으로 이동
+                    </button>
+                </form>
+            )}
 
-      {/* Step 4: 완료 */}
-      {step === 4 && (
-        <div className="reset-complete">
-          <h2>완료</h2>
-          <p>{message}</p>
-          <button type="button" className="login-button" onClick={handleGoLogin}>
-            로그인 화면으로 이동
-          </button>
+            {/* Step 4: 완료 */}
+            {step === 4 && (
+                <div className="reset-complete">
+                    <h2>완료</h2>
+                    <p>{message}</p>
+                    <button
+                        type="button"
+                        className="login-button"
+                        onClick={handleGoLogin}
+                    >
+                        로그인 화면으로 이동
+                    </button>
+                </div>
+            )}
         </div>
-      )}
-    </div>
-  );
+    );
 };
 
 export default ResetPasswordForm;

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -3,6 +3,7 @@ import Timer from "./Timer";
 import axiosInstance from "./utils/AxiosInstance";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 
 const ResetPasswordForm = () => {
     const [username, setUsername] = useState("");
@@ -37,7 +38,10 @@ const ResetPasswordForm = () => {
             });
             if (response.data?.success) {
                 setEmail(response.data.email); // 서버에서 받은 email 저장
-                setMessage("가입된 회원으로 인증코드를 보냈습니다.");
+                // alert(`${response.data.email}로 인증코드를 발송했습니다.`);
+                toast.success(
+                    `${response.data.email}로 인증코드를 발송했습니다.`,
+                );
                 setStep(2); // 인증코드 입력 단계로 이동
             } else {
                 setMessage(

--- a/src/components/Timer.css
+++ b/src/components/Timer.css
@@ -1,0 +1,6 @@
+.timer {
+    margin-top: 2px;
+    padding-left: var(--spacing-2-5);
+    color: #7b90a6;
+    font-size: var(--font-size-3xs);
+}

--- a/src/components/Timer.css
+++ b/src/components/Timer.css
@@ -1,6 +1,5 @@
 .timer {
-    margin-top: 2px;
-    padding-left: var(--spacing-2-5);
+    padding-left: var(--spacing-1-5);
     color: #7b90a6;
     font-size: var(--font-size-3xs);
 }

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -1,39 +1,43 @@
+import "./Timer.css";
 import { useState, useEffect, useRef } from "react";
-import "./Timer.css"
 
 const Timer = ({ duration, onExpire, triggerReset }) => {
-  const [remaining, setRemaining] = useState(duration);
-  const startTimeRef = useRef(null);
-  const rafId = useRef(null);
+    const [remaining, setRemaining] = useState(duration);
+    const startTimeRef = useRef(null);
+    const rafId = useRef(null);
 
-  useEffect(() => {
-    startTimeRef.current = Date.now();
+    useEffect(() => {
+        startTimeRef.current = Date.now();
 
-    const update = () => {
-      const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-      const left = duration - elapsed;
-      setRemaining(left > 0 ? left : 0);
+        const update = () => {
+            const elapsed = Math.floor(
+                (Date.now() - startTimeRef.current) / 1000,
+            );
+            const left = duration - elapsed;
+            setRemaining(left > 0 ? left : 0);
 
-      if (left <= 0) {
-        onExpire && onExpire();
-        cancelAnimationFrame(rafId.current);
-        return;
-      }
-      rafId.current = requestAnimationFrame(update);
+            if (left <= 0) {
+                onExpire && onExpire();
+                cancelAnimationFrame(rafId.current);
+                return;
+            }
+            rafId.current = requestAnimationFrame(update);
+        };
+
+        rafId.current = requestAnimationFrame(update);
+
+        return () => cancelAnimationFrame(rafId.current);
+    }, [duration, triggerReset, onExpire]);
+
+    const formatTime = (seconds) => {
+        const m = Math.floor(seconds / 60)
+            .toString()
+            .padStart(2, "0");
+        const s = (seconds % 60).toString().padStart(2, "0");
+        return `${m}:${s}`;
     };
 
-    rafId.current = requestAnimationFrame(update);
-
-    return () => cancelAnimationFrame(rafId.current);
-  }, [duration, triggerReset, onExpire]);
-
-  const formatTime = (seconds) => {
-    const m = Math.floor(seconds / 60).toString().padStart(2, "0");
-    const s = (seconds % 60).toString().padStart(2, "0");
-    return `${m}:${s}`;
-  };
-
-  return <div>{formatTime(remaining)}</div>;
+    return <div className="timer">{formatTime(remaining)}</div>;
 };
 
 export default Timer;

--- a/src/index.css
+++ b/src/index.css
@@ -35,3 +35,7 @@ body {
     white-space: nowrap;
     border: 0;
 }
+
+button:disabled {
+    cursor: default;
+}

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -1,7 +1,7 @@
-import { useSearchParams } from "react-router-dom";
-import RegisterForm from "../components/RegisterForm";
 import IntroBox from "../components/IntroBox";
+import RegisterForm from "../components/RegisterForm";
 import ResetPasswordForm from "../components/ResetPasswordForm";
+import { Link, useSearchParams } from "react-router-dom";
 
 const RegisterPage = () => {
     const [searchParams] = useSearchParams();
@@ -14,12 +14,18 @@ const RegisterPage = () => {
             </div>
             <div className="right-side">
                 <div className="form-container">
-                    <img
-                        className="logo-img"
-                        src="/icons/logo.svg"
-                        alt="logo_img"
-                    />
-                    {mode === "register" ? <RegisterForm /> : <ResetPasswordForm />}
+                    <Link to="/login">
+                        <img
+                            className="logo-img"
+                            src="/icons/logo.svg"
+                            alt="logo_img"
+                        />
+                    </Link>
+                    {mode === "register" ? (
+                        <RegisterForm />
+                    ) : (
+                        <ResetPasswordForm />
+                    )}
                 </div>
             </div>
         </div>

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -24,17 +24,27 @@ ul {
     font-size: 100%;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    all: unset;
+    display: block;
+}
+
 img {
     max-width: 100%;
     height: auto;
     display: block;
 }
 
-.lucide {
-    color: #121619;
+input {
+    all: unset;
+    box-sizing: border-box;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    all: unset;
-    display: block;
+.lucide {
+    color: #121619;
 }


### PR DESCRIPTION
## Summary

- 비밀번호 찾기에서 '학번/교번 입력', '인증코드 발송 및 확인' 단계의 기능 및 UI를 개선했습니다.

## Tasks

**1. 공통**
- import 정렬 플러그인 추가 (@trivago/prettier-plugin-sort-imports)
- App.css에 color, transition, spacing 변수 추가
- sonner 토스트 라이브러리 도입

**2. 비밀번호 찾기 - 학번/교번 입력 단계**
- 에러 메시지 및 입력 필드 스타일 개선

**3. 비밀번호 찾기 - 인증코드 입력 단계**
- 에러 메시지 및 입력 필드 스타일 개선
- 타이머 기능 추가 (5분 설정. 회원가입 폼도 동일하게 수정)
- 인증코드 재전송 기능 추가

## To Reviewer

- npm install 해주세요.

## Screenshot

- 학번/교번 입력
<img width="1608" height="1041" alt="스크린샷 2025-08-30 오전 4 14 25" src="https://github.com/user-attachments/assets/f3b834f1-31c2-4fc1-8b95-abd659e540b2" />

- 학번/교번 입력 - 에러 상태
<img width="1608" height="1041" alt="스크린샷 2025-08-30 오전 4 14 37" src="https://github.com/user-attachments/assets/b91a390a-b6bc-4966-ace3-2d5b2d3d9ad7" />

- 인증코드 발송 후 인증코드 입력 폼
<img width="1608" height="1041" alt="스크린샷 2025-08-30 오전 4 14 50" src="https://github.com/user-attachments/assets/4839cc04-b0db-4d6a-b1df-8afb92ec98ad" />
