### PR TITLE
[Design] 인증 페이지 반응형 스타일 개선

### DIFF
--- a/src/pages/AuthPage.css
+++ b/src/pages/AuthPage.css
@@ -32,8 +32,8 @@
 }
 
 .auth-page .logo-img {
-    width: 120px;
-    height: 60px;
+    width: 6.25rem;
+    height: 3.125rem;
 }
 
 @media (max-width: 1023px) {
@@ -43,12 +43,15 @@
     .auth-page .left-side {
         display: none;
     }
+    .auth-page .right-side {
+        width: 100%;
+    }
     .auth-page .logo-img {
         display: block;
         margin-left: auto;
         margin-right: auto;
     }
     .auth-page .form-container {
-        padding: 0 15px;
+        padding: 0 var(--spacing-4);
     }
 }


### PR DESCRIPTION
- 로그인 페이지 (iPhone 크기 - 393x852)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9aeadabe-00af-4bda-94f3-a5d89e951a70" />


- 회원가입, 로그인, 비밀번호 찾기 페이지에 적용
- 로고 이미지 축소
- 모바일에서 오른쪽 영역이 전체 폭 사용하도록 수정 후 패딩 조정