### PR TITLE
[Design] 게시글 상세 페이지 스타일 및 반응형 개선

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -110,7 +110,9 @@
     opacity: 0;
     visibility: hidden;
     transform: translateY(10px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition:
+        opacity 0.2s ease,
+        transform 0.2s ease;
     min-width: 240px;
 }
 
@@ -212,6 +214,7 @@
 .header-btn svg {
     flex: none;
     user-select: none;
+    color: #333;
 }
 
 .header .profile {
@@ -249,7 +252,9 @@
     border: 1px solid #cfd1d5;
     border-radius: 12px;
     background-color: #fff;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04), 0 16px 25px rgba(0, 0, 0, 0.1);
+    box-shadow:
+        0 4px 10px rgba(0, 0, 0, 0.04),
+        0 16px 25px rgba(0, 0, 0, 0.1);
 }
 
 .header .profile-menu-item {
@@ -432,7 +437,9 @@
     .header {
         background-color: var(--background-color);
         border: 0;
-        transition: top 0.25s, background-color 0.25s;
+        transition:
+            top 0.25s,
+            background-color 0.25s;
     }
 
     .header.shadow {

--- a/src/components/MyActivities.css
+++ b/src/components/MyActivities.css
@@ -61,7 +61,7 @@
   margin: 4px 0;
 }
 
-.post-meta {
+.MyActivities .post-meta {
   font-size: 12px;
   color: #999;
 }
@@ -127,9 +127,4 @@
   font-size: 14px;
   color: #555;
   margin: 4px 0;
-}
-
-.post-meta {
-  font-size: 12px;
-  color: #999;
 }

--- a/src/components/ProfileTemplate.css
+++ b/src/components/ProfileTemplate.css
@@ -1,27 +1,23 @@
 .ProfileTemplate {
-  display: inline-block;
+    display: inline-block;
 }
 
 .ProfileTemplate__search-result {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    cursor: pointer;
 }
 
 .ProfileTemplate__profile-img {
-  width: 27px;
-  height: 27px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: .7px solid #EAEAEB;
+    width: 27px;
+    height: 27px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 0.7px solid #eaeaeb;
 }
 
 .ProfileTemplate .ProfileTemplate__profile-name {
-  font-weight: 600;
-  font-size: var(--font-size-xs);
-}
-
-.ProfileTemplate__profile-name:hover {
-  text-decoration: underline;
+    font-weight: 600;
+    font-size: var(--font-size-xs);
 }

--- a/src/components/mypage/MyPosts.css
+++ b/src/components/mypage/MyPosts.css
@@ -82,7 +82,7 @@
   overflow: hidden;
   word-break: break-word;
 }
-.post-meta {
+.MyPosts .post-meta {
   margin-top: 6px;
   font-size: 12px;
   color: #6b7a8c;

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -20,7 +20,7 @@
 }
 
 .PostDetail .post-title {
-    font-size: 1.8rem;
+    font-size: var(--font-size-sm);
     font-weight: 700;
     color: #1f1f1f;
     margin: 0;

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -83,11 +83,26 @@
 }
 
 .PostDetail .post-content img {
-    max-width: 100%;
-    height: auto;
+    max-width: 100% !important;
+    height: auto !important;
     display: block;
     margin: 20px auto;
     border-radius: 10px;
+}
+
+.PostDetail .post-content table {
+    width: 100% !important;
+    max-width: 100% !important;
+    border-collapse: collapse;
+    table-layout: fixed;
+}
+
+.PostDetail .post-content th,
+.PostDetail .post-content td {
+    word-break: break-word;
+    white-space: normal;
+    padding: 0.5rem;
+    vertical-align: top;
 }
 
 .PostDetail .comment-header-wrap {

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -73,13 +73,13 @@
 
 .PostDetail .post-content-box {
     min-height: 400px;
+    margin-bottom: var(--spacing-5);
 }
 
 .PostDetail .post-content {
     font-size: var(--font-size-2xs);
     line-height: 1.8;
     color: #333;
-    margin-bottom: 24px;
 }
 
 .PostDetail .post-content img {
@@ -105,7 +105,7 @@
 }
 
 .PostDetail .post-content span {
-  font-size: inherit !important;
+    font-size: inherit !important;
 }
 
 .PostDetail .comment-header-wrap {
@@ -114,6 +114,20 @@
     justify-content: space-between;
     margin-top: 26px;
     line-height: 41px;
+}
+
+.PostDetail .link-area {
+    display: flex;
+    color: #237bd9;
+    font-size: var(--font-size-2xs);
+    align-items: center;
+    width: fit-content;
+    border-bottom: 1px solid #237bd9;
+}
+
+.PostDetail .link-area svg {
+    width: 1rem;
+    height: 1rem;
 }
 
 .PostDetail .comment-header {

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -123,11 +123,25 @@
     align-items: center;
     width: fit-content;
     border-bottom: 1px solid #237bd9;
+    margin-bottom: var(--spacing-6);
 }
 
 .PostDetail .link-area svg {
     width: 1rem;
     height: 1rem;
+}
+
+.PostDetail .react-area {
+    display: flex;
+    text-align: center;
+    align-items: center;
+    justify-content: center;
+}
+
+.PostDetail .react-area span {
+    font-size: var(--font-size-sm);
+    padding-left: var(--spacing-1-5);
+    color: #777;
 }
 
 .PostDetail .comment-header {

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -193,6 +193,7 @@
     display: flex;
     gap: 8px;
     margin-bottom: 16px;
+    flex-wrap: nowrap;
 }
 
 .PostDetail .comment-form input {
@@ -203,6 +204,7 @@
     border-radius: 6px;
     outline: none;
     transition: border-color 0.2s ease;
+    min-width: 0;
 }
 
 .PostDetail .comment-form input:focus {

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -413,6 +413,20 @@
     }
 }
 
+@media (max-width: 894px) {
+    .PostDetailPage {
+        width: 100%;
+    }
+
+    .PostDetailPage .PostDetail {
+        border-radius: 0;
+    }
+
+    .PostDetailPage .back-to-list-btn {
+        border-radius: 0;
+    }
+}
+
 @media (max-width: 767px) {
     .PostDetail .sort-button svg {
         width: 20px;

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -20,7 +20,7 @@
 }
 
 .PostDetail .post-title {
-    font-size: var(--font-size-sm);
+    font-size: 1.125rem;
     font-weight: 700;
     color: #1f1f1f;
     margin: 0;
@@ -31,13 +31,13 @@
 }
 
 .PostDetail .ProfileTemplate__profile-img {
-    width: var(--spacing-4);
-    height: var(--spacing-4);
+    width: 1.5rem;
+    height: 1.5rem;
 }
 
 .PostDetail .ProfileTemplate__profile-name {
     color: #616161;
-    font-size: var(--font-size-2xs);
+    font-size: 0.875rem;
 }
 
 .PostDetail .info-area {
@@ -45,7 +45,7 @@
     display: flex;
     justify-content: space-between;
     color: #949494;
-    font-size: var(--font-size-3xs);
+    font-size: 0.75rem;
     line-height: 1.5;
 }
 
@@ -61,8 +61,8 @@
 }
 
 .PostDetail .view svg {
-    width: var(--spacing-2);
-    height: var(--spacing-2);
+    width: 0.75rem;
+    height: 0.75rem;
     margin-right: 0.125rem;
 }
 
@@ -396,8 +396,8 @@
 }
 
 .PostDetailPage .scrap-btn svg {
-    width: var(--spacing-3);
-    height: var(--spacing-3);
+    width: 1rem;
+    height: 1rem;
     margin-right: 2px;
 }
 

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -76,7 +76,7 @@
 }
 
 .PostDetail .post-content {
-    font-size: 1rem;
+    font-size: var(--font-size-2xs);
     line-height: 1.8;
     color: #333;
     margin-bottom: 24px;
@@ -102,7 +102,10 @@
     word-break: break-word;
     white-space: normal;
     vertical-align: top;
-    font-size: var(--font-size-2xs);
+}
+
+.PostDetail .post-content span {
+  font-size: inherit !important;
 }
 
 .PostDetail .comment-header-wrap {

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -16,7 +16,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 8px;
+    margin-bottom: 0.563rem;
 }
 
 .PostDetail .post-title {
@@ -24,6 +24,46 @@
     font-weight: 700;
     color: #1f1f1f;
     margin: 0;
+}
+
+.PostDetail .ProfileTemplate__search-result {
+    gap: 0.25rem;
+}
+
+.PostDetail .ProfileTemplate__profile-img {
+    width: var(--spacing-4);
+    height: var(--spacing-4);
+}
+
+.PostDetail .ProfileTemplate__profile-name {
+    color: #616161;
+    font-size: var(--font-size-2xs);
+}
+
+.PostDetail .info-area {
+    padding-top: 0.375rem;
+    display: flex;
+    justify-content: space-between;
+    color: #949494;
+    font-size: var(--font-size-3xs);
+    line-height: 1.5;
+}
+
+.PostDetail .info-left {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.PostDetail .view {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.PostDetail .view svg {
+    width: var(--spacing-2);
+    height: var(--spacing-2);
+    margin-right: 0.125rem;
 }
 
 .like-container {
@@ -58,7 +98,6 @@
 }
 
 .PostDetail .post-meta {
-    color: #999;
     font-size: 14px;
     margin-bottom: 20px;
 }

--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -101,8 +101,8 @@
 .PostDetail .post-content td {
     word-break: break-word;
     white-space: normal;
-    padding: 0.5rem;
     vertical-align: top;
+    font-size: var(--font-size-2xs);
 }
 
 .PostDetail .comment-header-wrap {

--- a/src/components/post/PostDetail.jsx
+++ b/src/components/post/PostDetail.jsx
@@ -6,12 +6,12 @@ import { UserContext } from "../utils/UserContext";
 import CommentBox from "./CommentBox";
 import MenuButton from "./MenuButton";
 import "./PostDetail.css";
-import { Heart, Check, List, Bookmark } from "lucide-react";
+import { Heart, Check, List, Bookmark, ChevronsRight } from "lucide-react";
 import { useEffect, useState, useRef, useContext } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-
+import { useParams, useNavigate, Link } from "react-router-dom";
 // 좋아요 API 함수
 import { toast } from "sonner";
+
 const PostDetail = () => {
     const { postId } = useParams();
     const [post, setPost] = useState(null);
@@ -31,7 +31,6 @@ const PostDetail = () => {
     const lastSubmitTime = useRef(0);
     const navigate = useNavigate();
     const { hasRole, user } = useContext(UserContext); // ✅ 현재 로그인 사용자 권한 확인
-
 
     useEffect(() => {
         fetchPost();
@@ -99,10 +98,10 @@ const PostDetail = () => {
             prev.map((c) =>
                 c.id === commentId
                     ? {
-                        ...c,
-                        liked: !c.liked,
-                        likes: (c.likes || 0) + (c.liked ? -1 : 1),
-                    }
+                          ...c,
+                          liked: !c.liked,
+                          likes: (c.likes || 0) + (c.liked ? -1 : 1),
+                      }
                     : c,
             ),
         );
@@ -131,7 +130,8 @@ const PostDetail = () => {
 
     const canComment = () =>
         user?.roles?.some(
-            (role) => roleHierarchy.indexOf(role) >= roleHierarchy.indexOf("STUDENT")
+            (role) =>
+                roleHierarchy.indexOf(role) >= roleHierarchy.indexOf("STUDENT"),
         );
 
     const handleCommentSubmit = async () => {
@@ -141,7 +141,11 @@ const PostDetail = () => {
         }
 
         const now = Date.now();
-        if (!newComment.trim() || isSubmitting || now - lastSubmitTime.current < 1000)
+        if (
+            !newComment.trim() ||
+            isSubmitting ||
+            now - lastSubmitTime.current < 1000
+        )
             return;
 
         setIsSubmitting(true);
@@ -154,7 +158,8 @@ const PostDetail = () => {
             setNewComment("");
             await fetchComments();
         } catch (err) {
-            const message = err.response?.data?.message || "댓글 등록에 실패했습니다.";
+            const message =
+                err.response?.data?.message || "댓글 등록에 실패했습니다.";
             toast.error(message);
         } finally {
             setIsSubmitting(false);
@@ -168,7 +173,11 @@ const PostDetail = () => {
         }
 
         const now = Date.now();
-        if (!replyContent.trim() || isSubmitting || now - lastSubmitTime.current < 1000)
+        if (
+            !replyContent.trim() ||
+            isSubmitting ||
+            now - lastSubmitTime.current < 1000
+        )
             return;
 
         setIsSubmitting(true);
@@ -184,7 +193,8 @@ const PostDetail = () => {
             setReplyingTo(null);
             await fetchReplies(parentId);
         } catch (err) {
-            const message = err.response?.data?.message || "답글 등록에 실패했습니다.";
+            const message =
+                err.response?.data?.message || "답글 등록에 실패했습니다.";
             toast.error(message);
         } finally {
             setIsSubmitting(false);
@@ -280,19 +290,21 @@ const PostDetail = () => {
                     )}
                     <div>
                         {post.createdDate
-                            ? new Date(post.createdDate).toLocaleString("ko-KR", {
-                                year: "numeric",
-                                month: "2-digit",
-                                day: "2-digit",
-                                hour: "2-digit",
-                                minute: "2-digit",
-                                hour12: false, // ✅ 24시간 표기
-                            })
+                            ? new Date(post.createdDate).toLocaleString(
+                                  "ko-KR",
+                                  {
+                                      year: "numeric",
+                                      month: "2-digit",
+                                      day: "2-digit",
+                                      hour: "2-digit",
+                                      minute: "2-digit",
+                                      hour12: false, // ✅ 24시간 표기
+                                  },
+                              )
                             : ""}
                         {" | "}조회 {post.viewCount}
                     </div>
                 </div>
-
 
                 {post.boardType === "MARKET" ? (
                     <div className="market-horizontal-layout">
@@ -335,6 +347,18 @@ const PostDetail = () => {
                                 }}
                             ></div>
                         </section>
+                        {post.targetUrl && (
+                            <Link
+                                to={post.targetUrl}
+                                target="_blank"
+                                className="link-area"
+                            >
+                                {post.boardType === "NOTICE_UNIV"
+                                    ? "학교"
+                                    : "학과"}{" "}
+                                홈페이지에서 보기 <ChevronsRight />
+                            </Link>
+                        )}
                     </>
                 )}
 
@@ -344,8 +368,9 @@ const PostDetail = () => {
                     </span>
                     <div className="sort-controls">
                         <button
-                            className={`sort-button ${sortOrder === "oldest" ? "active" : ""
-                                }`}
+                            className={`sort-button ${
+                                sortOrder === "oldest" ? "active" : ""
+                            }`}
                             onClick={() => {
                                 setSortOrder("oldest");
                                 setComments(sortComments(comments, "oldest"));
@@ -356,8 +381,9 @@ const PostDetail = () => {
                             등록순
                         </button>
                         <button
-                            className={`sort-button ${sortOrder === "newest" ? "active" : ""
-                                }`}
+                            className={`sort-button ${
+                                sortOrder === "newest" ? "active" : ""
+                            }`}
                             onClick={() => {
                                 setSortOrder("newest");
                                 setComments(sortComments(comments, "newest"));

--- a/src/components/post/PostDetail.jsx
+++ b/src/components/post/PostDetail.jsx
@@ -243,17 +243,6 @@ const PostDetail = () => {
                 <div className="post-title-with-like">
                     <h2 className="post-title">{post.title}</h2>
                     <div className="like-container">
-                        <button
-                            className={`like-toggle-button${liked ? " liked" : ""}`}
-                            onClick={handleLikeBtnClick}
-                        >
-                            <Heart
-                                color={liked ? "#e74c3c" : "#aaa"}
-                                fill={liked ? "#e74c3c" : "none"}
-                            />
-                        </button>
-                        <span>{likenum}</span>
-
                         {/* 스크랩 버튼 */}
                         <button
                             className={`scrap-btn${scrapped ? " scrapped" : ""}`}
@@ -359,6 +348,20 @@ const PostDetail = () => {
                                 홈페이지에서 보기 <ChevronsRight />
                             </Link>
                         )}
+
+                        {/* 좋아요 버튼 */}
+                        <div className="react-area">
+                            <button
+                                className={`like-toggle-button${liked ? " liked" : ""}`}
+                                onClick={handleLikeBtnClick}
+                            >
+                                <Heart
+                                    color={liked ? "#e74c3c" : "#aaa"}
+                                    fill={liked ? "#e74c3c" : "none"}
+                                />
+                            </button>
+                            <span>{likenum}</span>
+                        </div>
                     </>
                 )}
 

--- a/src/components/post/PostDetail.jsx
+++ b/src/components/post/PostDetail.jsx
@@ -254,18 +254,6 @@ const PostDetail = () => {
                 <div className="post-title-with-like">
                     <h2 className="post-title">{post.title}</h2>
                     <div className="like-container">
-                        {/* 스크랩 버튼 */}
-                        <button
-                            className={`scrap-btn${scrapped ? " scrapped" : ""}`}
-                            onClick={handleScrapBtnClick}
-                        >
-                            <Bookmark
-                                color={scrapped ? "#3399ff" : "#aaa"}
-                                fill={scrapped ? "#3399ff" : "none"}
-                            />
-                            <span>스크랩</span>
-                        </button>
-
                         {post.isAuthor && (
                             <MenuButton
                                 onEdit={() =>
@@ -300,7 +288,19 @@ const PostDetail = () => {
                                 {post.viewCount}
                             </div>
                         </div>
-                        <div className="info-right"></div>
+                        <div className="info-right">
+                            {/* 스크랩 버튼 */}
+                            <button
+                                className={`scrap-btn${scrapped ? " scrapped" : ""}`}
+                                onClick={handleScrapBtnClick}
+                            >
+                                <Bookmark
+                                    color={scrapped ? "#3399ff" : "#aaa"}
+                                    fill={scrapped ? "#3399ff" : "none"}
+                                />
+                                <span>스크랩</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
 

--- a/src/pages/BoardPage.css
+++ b/src/pages/BoardPage.css
@@ -14,8 +14,7 @@
 }
 .BoardPage .content-container {
     max-width: 1280px;
-
-    width: 80%;
+    width: 100%;
     margin: 0 auto;
 }
 

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -46,5 +46,5 @@ input {
 }
 
 .lucide {
-    color: #121619;
+    color: inherit;
 }


### PR DESCRIPTION
- 게시글 상세 페이지 - 데스크탑 화면
<img width="5000" alt="image" src="https://github.com/user-attachments/assets/76d64e33-d401-4790-92e5-66f0aaa2077e" />

- 게시글 상세 페이지 - 모바일 화면
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7e528287-d72c-49e1-9007-f848629cb094" />


작업 내용
-
- 폰트 사이즈 축소
- 좋아요 버튼 하단으로 이동
- 작성자, 작성일, 조회수 디자인 개선, 스크랩 버튼 살짝 아래로 이동
- 모바일 화면에서 댓글 영역 넘치는 문제 수정
- 모바일 화면에서 게시글 너비 100%로 변경 및 border-radius 제거
- 크롤링 게시글 UI 개선
  - 모바일 화면에서 이미지 등 본문 너비 벗어나는 문제 수정
  - 본문 폰트 사이즈 14px로 통일
  - 불필요한 패딩 제거
  - 본문 하단에 원본 게시글 링크 영역 추가