### PR TITLE
[Fix] 크롤링 공지사항 테이블 반응형 오버플로우 수정

### DIFF
--- a/src/components/post/PostDetail.css
+++ b/src/components/post/PostDetail.css
@@ -137,11 +137,17 @@
     border-collapse: collapse;
 }
 
+.PostDetail .post-content table[style*="width"] {
+    width: 100% !important;
+}
+
 .PostDetail .post-content th,
 .PostDetail .post-content td {
     word-break: break-word;
     white-space: normal;
     vertical-align: top;
+    width: auto !important;
+    max-width: none !important;
 }
 
 .PostDetail .post-content span {


### PR DESCRIPTION
## Summary

- 학교/학과 공지사항의 고정 너비 테이블이 작은 화면에서 넘치는 문제 해결

## Tasks

- `table-layout: fixed` 및 `width: auto !important` 적용
- 인라인 스타일(782px, 726px 등)을 강제 오버라이드
- 819px 이하 화면에서 테이블이 부모 컨테이너를 벗어나지 않도록 수정

## Screenshot

- 수정 전
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d392f7a9-1721-43c3-926c-f10e959d5595" />

- 수정 후
<img width="300" alt="모아이 | 모여라, AI" src="https://github.com/user-attachments/assets/be64df28-b2ba-473d-940b-276f815a6514" />